### PR TITLE
Add systemd DISTRO_FEATURE for OSTree

### DIFF
--- a/conf/distro/sota.conf.inc
+++ b/conf/distro/sota.conf.inc
@@ -24,4 +24,6 @@ UBOOT_MACHINE_raspberrypi3 = "rpi_3_32b_defconfig"
 PREFERRED_PROVIDER_virtual/bootloader_raspberrypi2 = "u-boot"
 PREFERRED_PROVIDER_virtual/bootloader_raspberrypi3 = "u-boot"
 
+DISTRO_FEATURES_append = " systemd"
+
 DISTROOVERRIDES_append = ":sota"


### PR DESCRIPTION
OSTree can't currently work without systemd (to my knowledge, some more research can be done here) so we have to make this mandatory.