### PR TITLE
Create sota_bleeding.inc config file to build against master

### DIFF
--- a/conf/include/local/sota_bleeding.inc
+++ b/conf/include/local/sota_bleeding.inc
@@ -1,0 +1,1 @@
+SRCREV_pn-aktualizr ?= "${AUTOREV}"

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -9,6 +9,7 @@ LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=9741c346eef56131163e13b9db1241b3"
 inherit cmake systemd
 
 S = "${WORKDIR}/git"
+PV = "1.0+git${SRCPV}"
 
 SRCREV = "f2275e9938f5c942c9e51a3966b1ad91acd65367"
 


### PR DESCRIPTION
This overrides the package version for Aktualizr to be latest master. This is
recommended for development and test only.  To use it, add the following to
local.conf:

require conf/include/local/sota_bleeding.inc