### PR TITLE
Create a wrapper so OSTree can find ostree-grub-generator

### DIFF
--- a/recipes-sota/ostree/ostree_git.bb
+++ b/recipes-sota/ostree/ostree_git.bb
@@ -67,6 +67,11 @@ do_install_append() {
  fi
 }
 
+do_install_append_class-native() {
+	create_wrapper ${D}${bindir}/ostree OSTREE_GRUB2_EXEC="${STAGING_LIBDIR_NATIVE}/ostree/ostree-grub-generator"
+}
+
+
 FILES_${PN} += " \
     ${@'${systemd_unitdir}/system/' if d.getVar('SYSTEMD_REQUIRED', True) else ''} \
     ${@'${libdir}/dracut/modules.d/98ostree/module-setup.sh' if d.getVar('SYSTEMD_REQUIRED', True) else ''} \


### PR DESCRIPTION
OSTree has a hardcoded path to ostree-grub-generator, this wrapper sets it
dynamically to avoid problems with sharing a SSTATE cache.