### PR TITLE
Set default DISTRO, disable prelink

### DIFF
--- a/conf/distro/sota.conf.inc
+++ b/conf/distro/sota.conf.inc
@@ -24,3 +24,5 @@ OSTREE_BRANCHNAME ?= "ota-${MACHINE}"
 OSTREE_OSNAME ?= "poky"
 OSTREE_INITRAMFS_IMAGE ?= "initramfs-ostree-image"
 
+# Prelinking increases the size of downloads and causes build errors
+USER_CLASSES_remove = "image-prelink"

--- a/scripts/envsetup.sh
+++ b/scripts/envsetup.sh
@@ -49,5 +49,6 @@ else
 	cat ${METADIR}/meta-updater/conf/include/bblayers/sota_${MACHINE}.inc >> conf/bblayers.conf
 	echo "include conf/include/local/sota_${MACHINE}.inc" >> conf/local.conf
 	echo "include conf/distro/sota.conf.inc" >> conf/local.conf
+	echo "DISTRO = \"poky-sota-systemd\"" >> conf/local.conf
 fi
 


### PR DESCRIPTION
Setting the default DISTRO to include systemd means that the rvi-sota-client
starts by default, making it work 'out of the box'.  image-prelink seems to be
broken at the moment, so I've disabled it by default.