### PR TITLE
Mount the root filesystem by label rather than path

### DIFF
--- a/conf/include/local/sota_minnowboard.inc
+++ b/conf/include/local/sota_minnowboard.inc
@@ -6,4 +6,4 @@ EFI_PROVIDER = "grub-efi"
 WKS_FILE = "efiimage-sota.wks"
 IMAGE_BOOT_FILES = ""
 
-OSTREE_KERNEL_ARGS ?= "ramdisk_size=16384 rw rootfstype=ext4 rootwait rootdelay=2 ostree_root=/dev/mmcblk2p2 console=ttyS0,115200 console=tty0"
+OSTREE_KERNEL_ARGS ?= "ramdisk_size=16384 rw rootfstype=ext4 rootwait rootdelay=2 console=ttyS0,115200 console=tty0"

--- a/recipes-sota/ostree-initrd/files/init.sh
+++ b/recipes-sota/ostree-initrd/files/init.sh
@@ -29,10 +29,11 @@ get_ostree_sysroot() {
 	for opt in `cat /proc/cmdline`; do
 		arg=`echo $opt | cut -d'=' -f1`
 		if [ $arg == "ostree_root" ]; then
-			echo $opt | cut -d'=' -f2
+			echo $opt | cut -d'=' -f2-
 			return
 		fi
 	done
+	echo "LABEL=otaroot"
 }
 
 export PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/lib/ostree

--- a/recipes-sota/ostree-initrd/ostree-initrd.bb
+++ b/recipes-sota/ostree-initrd/ostree-initrd.bb
@@ -5,15 +5,16 @@ SRC_URI = "file://init.sh"
 
 S = "${WORKDIR}"
 
+PV = "2"
+
 do_install() {
 	install -dm 0755 ${D}/etc
 	touch ${D}/etc/initrd-release
 	install -dm 0755 ${D}/dev
 	install -dm 0755 ${D}/sbin
-        install -m 0755 ${WORKDIR}/init.sh ${D}/sbin/init
+	install -m 0755 ${WORKDIR}/init.sh ${D}/sbin/init
 }
 
 inherit allarch
 
 FILES_${PN} += " /dev /etc/initrd-release /sbin/init "
-


### PR DESCRIPTION
Support identifying the root filesystem via a kernel command line like
'ostree_root=LABEL=mylabel'. Also make it mount a filesystem labeled 'otaroot'
by default.

This means it is possible to test the Minnowboard build in Qemu.