### PR TITLE
Move rvi-sota-client to poky-sota-systemd.conf

### DIFF
--- a/conf/distro/poky-sota-systemd.conf
+++ b/conf/distro/poky-sota-systemd.conf
@@ -9,4 +9,4 @@ DISTRO_CODENAME = "sota"
 DISTRO_FEATURES_append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 
-IMAGE_INSTALL_append = " connman connman-client"
+IMAGE_INSTALL_append = " connman connman-client rvi-sota-client"

--- a/conf/distro/sota.conf.inc
+++ b/conf/distro/sota.conf.inc
@@ -1,7 +1,7 @@
 DISTRO_FEATURES_append = " sota"
 OVERRIDES .= ":sota"
 
-IMAGE_INSTALL_append = " ostree os-release rvi-sota-client"
+IMAGE_INSTALL_append = " ostree os-release"
 
 # live image for OSTree-enabled systems
 IMAGE_CLASSES += "image_types_ostree image_types_ota"


### PR DESCRIPTION
sota-client is optional for external projects, such as AGL, build it only if using our own envsetup