### PR TITLE
Extract common distro configuration into sota.conf.inc

### DIFF
--- a/conf/distro/poky-sota-systemd.conf
+++ b/conf/distro/poky-sota-systemd.conf
@@ -1,6 +1,6 @@
 require conf/distro/poky.conf
 
-DISTRO_FEATURES_append = " sota"
+require conf/distro/sota.conf.inc
 
 DISTRO = "poky-sota"
 DISTRO_NAME = "OTA-enabled Linux"
@@ -10,8 +10,4 @@ DISTRO_CODENAME = "sota"
 DISTRO_FEATURES_append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 
-INHERIT_prepend = " sota"
 IMAGE_INSTALL_append = " connman connman-client rvi-sota-client"
-
-# Prelinking increases the size of downloads and causes build errors
-USER_CLASSES_remove = "image-prelink"

--- a/conf/distro/poky-sota.conf
+++ b/conf/distro/poky-sota.conf
@@ -1,14 +1,9 @@
 require conf/distro/poky.conf
-
-DISTRO_FEATURES_append = " sota"
+require conf/distro/sota.conf.inc
 
 DISTRO = "poky-sota"
 DISTRO_NAME = "OTA-enabled Linux"
 DISTRO_VERSION = "1.0"
 DISTRO_CODENAME = "sota"
 
-INHERIT += " sota"
 IMAGE_INSTALL_append = " connman connman-client"
-
-# Prelinking increases the size of downloads and causes build errors
-USER_CLASSES_remove = "image-prelink"

--- a/conf/distro/sota.conf.inc
+++ b/conf/distro/sota.conf.inc
@@ -1,0 +1,11 @@
+# Common settings to enable SOTA
+# This can be pulled into a custom distribution, or included in
+# local.conf directly with:
+#
+# require conf/distro/sota.conf.inc
+
+DISTRO_FEATURES_append = " sota"
+INHERIT += " sota"
+IMAGE_INSTALL_append = " aktualizr"
+# Prelinking increases the size of downloads and causes build errors
+USER_CLASSES_remove = "image-prelink"


### PR DESCRIPTION
Pull the common lines from the poky-sota.conf and poky-sota-systemd.conf
example distributions into a separate include file that can be pulled into
other environments.

This might be by including it in a user's own custom distro, or by directly
including it in local.conf (e.g. AGL).

  require conf/distro/sota.conf.inc