### PR TITLE
Prefix OSTREE_BRANCHNAME with ${MACHINE}-

### DIFF
--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -15,7 +15,8 @@ EXTRA_IMAGEDEPENDS_append_sota = " parted-native mtools-native dosfstools-native
 
 # Please redefine OSTREE_REPO in order to have a persistent OSTree repo
 OSTREE_REPO ?= "${DEPLOY_DIR_IMAGE}/ostree_repo"
-OSTREE_BRANCHNAME ?= "ota-${MACHINE}"
+# For UPTANE operation, OSTREE_BRANCHNAME must start with "${MACHINE}-"
+OSTREE_BRANCHNAME ?= "${MACHINE}-ota"
 OSTREE_OSNAME ?= "poky"
 OSTREE_INITRAMFS_IMAGE ?= "initramfs-ostree-image"
 


### PR DESCRIPTION
As a temporary fix, treehub is going to use this to derive the relevant
hardwareIdentifier for a push.