### PR TITLE
Support Aktualizr in manual-provisioning mode

### DIFF
--- a/classes/image_types_ota.bbclass
+++ b/classes/image_types_ota.bbclass
@@ -99,6 +99,8 @@ IMAGE_CMD_otaimg () {
 		tar --xattrs --xattrs-include='*' -C ${HOME_TMP} -xf ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.rootfs.ostree.tar.bz2 ./usr/homedirs ./var/sota || true
  		mv ${HOME_TMP}/var/sota ${PHYS_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/ || true
 		mv ${HOME_TMP}/usr/homedirs/home ${PHYS_SYSROOT}/ || true
+		# Ensure that /var/local exists (AGL symlinks /usr/local to /var/local)
+		install -d ${PHYS_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/local
 		rm -rf ${HOME_TMP}
 
 		# Calculate image type

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -2,24 +2,38 @@ SUMMARY = "Aktualizr SOTA Client"
 DESCRIPTION = "SOTA Client application written in C++"
 HOMEPAGE = "https://github.com/advancedtelematic/aktualizr"
 SECTION = "base"
-
 LICENSE = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=9741c346eef56131163e13b9db1241b3"
+DEPENDS = "boost curl openssl jansson libsodium ostree"
+SRCREV = "4e9344ae375a444f02b964dca52fe808010d17df"
+PV = "1.0+git${SRCPV}"
+
+SRC_URI = " \
+  git://github.com/advancedtelematic/aktualizr \
+  file://aktualizr-manual-provision.service \
+  "
+
+S = "${WORKDIR}/git"
+SYSTEMD_SERVICE_${PN} = "aktualizr.service"
 
 inherit cmake systemd
 
-S = "${WORKDIR}/git"
-PV = "1.0+git${SRCPV}"
-
-SRCREV = "4e9344ae375a444f02b964dca52fe808010d17df"
-
-SRC_URI = "git://github.com/advancedtelematic/aktualizr"
-
-DEPENDS = "boost curl openssl jansson libsodium ostree"
-RDEPENDS = ""
-
 EXTRA_OECMAKE = "-DWARNING_AS_ERROR=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF -DBUILD_OSTREE=ON"
+
+export SOTA_AUTOPROVISION_CREDENTIALS
+
+do_install_append() {
+    if [ -n "$SOTA_AUTOPROVISION_CREDENTIALS" ]; then
+      bbwarn "Aktualizr recipe currently lacks support for SOTA_AUTOPROVISION_CREDENTIALS. No systemd service will be created"
+    else
+      install -d ${D}/${systemd_unitdir}/system
+      install -m 0644 ${WORKDIR}/aktualizr-manual-provision.service ${D}/${systemd_unitdir}/system/aktualizr.service
+    fi
+}
+
+RDEPENDS = ""
 
 FILES_${PN} = " \
                 ${bindir}/aktualizr \
-		"
+                ${systemd_unitdir}/system/aktualizr.service \
+                "

--- a/recipes-sota/aktualizr/files/aktualizr-manual-provision.service
+++ b/recipes-sota/aktualizr/files/aktualizr-manual-provision.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Aktualizr SOTA Client
+Wants=network-online.target
+After=network.target network-online.target
+Requires=network-online.target
+
+[Service]
+RestartSec=10
+Restart=always
+ExecStart=/usr/bin/aktualizr --config /sysroot/boot/sota.toml --loglevel 2
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Aktualizr currently supports OSTree updates in non-autoprovisioned mode. Add a
systemd service to run it in that mode. It uses the same location for the
config file as rvi-sota-client (/sysroot/boot/sota.toml)

Also, the aktualizr recipe is reformatted according to
meta-openembedded/contrib/oe-stylize.py (which follows the OE styleguide)