### PR TITLE
Add option to choose which sota client to use (if any)

### DIFF
--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -5,7 +5,7 @@ python __anonymous() {
 
 OVERRIDES .= "${@bb.utils.contains('DISTRO_FEATURES', 'sota', ':sota', '', d)}"
 
-IMAGE_INSTALL_append_sota = " ostree os-release"
+IMAGE_INSTALL_append_sota = " ostree os-release ${SOTA_CLIENT}"
 IMAGE_CLASSES += " image_types_ostree image_types_ota"
 IMAGE_FSTYPES += "${@bb.utils.contains('DISTRO_FEATURES', 'sota', 'ostreepush otaimg wic', ' ', d)}"
 

--- a/conf/distro/poky-sota-systemd.conf
+++ b/conf/distro/poky-sota-systemd.conf
@@ -10,4 +10,4 @@ DISTRO_CODENAME = "sota"
 DISTRO_FEATURES_append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 
-IMAGE_INSTALL_append = " connman connman-client rvi-sota-client"
+IMAGE_INSTALL_append = " connman connman-client"

--- a/conf/distro/sota.conf.inc
+++ b/conf/distro/sota.conf.inc
@@ -6,6 +6,6 @@
 
 DISTRO_FEATURES_append = " sota"
 INHERIT += " sota"
-IMAGE_INSTALL_append = " aktualizr"
+SOTA_CLIENT ?= "aktualizr"
 # Prelinking increases the size of downloads and causes build errors
 USER_CLASSES_remove = "image-prelink"


### PR DESCRIPTION
Client can be changed to the rust one by adding 'SOTA_CLIENT = "rvi-sota-client"' to local.conf