### PR TITLE
Set default SOTA_CLIENT directly in sota.bbclass

### DIFF
--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -5,6 +5,7 @@ python __anonymous() {
 
 OVERRIDES .= "${@bb.utils.contains('DISTRO_FEATURES', 'sota', ':sota', '', d)}"
 
+SOTA_CLIENT ??= aktualizr
 IMAGE_INSTALL_append_sota = " ostree os-release ${SOTA_CLIENT}"
 IMAGE_CLASSES += " image_types_ostree image_types_ota"
 IMAGE_FSTYPES += "${@bb.utils.contains('DISTRO_FEATURES', 'sota', 'ostreepush otaimg wic', ' ', d)}"

--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -5,7 +5,7 @@ python __anonymous() {
 
 OVERRIDES .= "${@bb.utils.contains('DISTRO_FEATURES', 'sota', ':sota', '', d)}"
 
-SOTA_CLIENT ??= aktualizr
+SOTA_CLIENT ??= "aktualizr"
 IMAGE_INSTALL_append_sota = " ostree os-release ${SOTA_CLIENT}"
 IMAGE_CLASSES += " image_types_ostree image_types_ota"
 IMAGE_FSTYPES += "${@bb.utils.contains('DISTRO_FEATURES', 'sota', 'ostreepush otaimg wic', ' ', d)}"

--- a/conf/distro/sota.conf.inc
+++ b/conf/distro/sota.conf.inc
@@ -6,6 +6,5 @@
 
 DISTRO_FEATURES_append = " sota"
 INHERIT += " sota"
-SOTA_CLIENT ?= "aktualizr"
 # Prelinking increases the size of downloads and causes build errors
 USER_CLASSES_remove = "image-prelink"


### PR DESCRIPTION
In some use cases (etc. AGL) we don't include sota.conf.inc which will result in unset SOTA_CLIENT. Surprisingly, unset variables ARE NOT resolved to empty strings by bitbake, so the build fails in these cases.