### PR TITLE
Override IMAGE_ROOTFS_EXTRA_SPACE

### DIFF
--- a/recipes-core/images/initramfs-ostree-image.bb
+++ b/recipes-core/images/initramfs-ostree-image.bb
@@ -21,6 +21,10 @@ inherit core-image
 
 IMAGE_ROOTFS_SIZE = "8192"
 
+# Users will often ask for extra space in their rootfs by setting this
+# globally.  Since this is a initramfs, we don't want to make it bigger
+IMAGE_ROOTFS_EXTRA_SPACE = "0"
+
 BAD_RECOMMENDATIONS += "busybox-syslog"
 
 


### PR DESCRIPTION
AGL sets this to 500MB to allow extra space in the default image.  Set it to 0
in the initramfs.