### PR TITLE
image_types_ostree.bbclass: Fix path to unzip

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -5,7 +5,8 @@ inherit image
 IMAGE_DEPENDS_ostree = "ostree-native:do_populate_sysroot \ 
 			openssl-native:do_populate_sysroot \
 			virtual/kernel:do_deploy \
-			${OSTREE_INITRAMFS_IMAGE}:do_image_complete"
+			${OSTREE_INITRAMFS_IMAGE}:do_image_complete \
+			unzip-native"
 
 export OSTREE_REPO
 export OSTREE_BRANCHNAME


### PR DESCRIPTION
The creation of images, such as rpi-basic-image failed
on branch Pyro due to missing/wrong path to unzip.
This patch ensures that unzip is called with its
full path from the bindir.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>