### PR TITLE
Do not enforce IMAGE_FSTYPES (board specific)

### DIFF
--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -7,8 +7,8 @@ OVERRIDES .= "${@bb.utils.contains('DISTRO_FEATURES', 'sota', ':sota', '', d)}"
 
 SOTA_CLIENT ??= "aktualizr"
 IMAGE_INSTALL_append_sota = " ostree os-release ${SOTA_CLIENT}"
-IMAGE_CLASSES += " image_types_ostree image_types_ota"
-IMAGE_FSTYPES += "${@bb.utils.contains('DISTRO_FEATURES', 'sota', 'ostreepush otaimg wic', ' ', d)}"
+IMAGE_CLASSES += " image_types_ostree"
+IMAGE_FSTYPES += "${@bb.utils.contains('DISTRO_FEATURES', 'sota', 'ostreepush', ' ', d)}"
 
 WKS_FILE_sota ?= "sdimage-sota.wks"
 


### PR DESCRIPTION
IMAGE_FSTYPES += "otaimg wic" and IMAGE_CLASSES += "image_types_ota"   are board specific extensions, move down into board specific files.