### PR TITLE
Add LICENSE and SRC_URI variable in recipe

### DIFF
--- a/recipes-bsp/u-boot/u-boot_2016.11.bb
+++ b/recipes-bsp/u-boot/u-boot_2016.11.bb
@@ -1,8 +1,17 @@
 require recipes-bsp/u-boot/u-boot.inc
 
+HOMEPAGE = "http://www.denx.de/wiki/U-Boot/WebHome"
+SECTION = "bootloaders"
+
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=a2c678cfd4a4d97135585cad908541c6"
+PE = "1"
+
 DEPENDS += "dtc-native"
 
 SRCREV = "5ea3e51fc481613a8dee8c02848d1b42c81ad892"
+SRC_URI = "git://git.denx.de/u-boot.git"
+S = "${WORKDIR}/git"
 
 PV = "v2016.11+git${SRCPV}"
 


### PR DESCRIPTION
In pyro, u-boot-common_2017.01.inc is created. In the inc file,
SRC_URI and LICENSE are defined. So u-boot_2016.11 needs those variables

Signed-off-by: Changhyeok Bae <changhyeok.bae@gmail.com>