### PR TITLE
glib-networking_%.bbappend: Add again hackery

### DIFF
--- a/recipes-support/glib-networking/glib-networking_%.bbappend
+++ b/recipes-support/glib-networking/glib-networking_%.bbappend
@@ -1,2 +1,6 @@
 BBCLASSEXTEND_append_sota = " native nativesdk"
 
+# Hackery to prevent relocatable_native_pcfiles from crashing
+do_install_append_class-native () {
+        rmdir ${D}${libdir}/pkgconfig
+}


### PR DESCRIPTION
Revert the change from 24 Jul and add again the
hackery which removes removes pkgconfig.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>