### PR TITLE
Make initramfs size more deterministic

### DIFF
--- a/recipes-core/images/initramfs-ostree-image.bb
+++ b/recipes-core/images/initramfs-ostree-image.bb
@@ -20,6 +20,8 @@ IMAGE_CLASSES_append_arm = " image_types_uboot"
 inherit core-image
 
 IMAGE_ROOTFS_SIZE = "8192"
+IMAGE_ROOTFS_EXTRA_SPACE = "0"
+IMAGE_OVERHEAD_FACTOR = "1.0"
 
 # Users will often ask for extra space in their rootfs by setting this
 # globally.  Since this is a initramfs, we don't want to make it bigger


### PR DESCRIPTION
Set 
IMAGE_ROOTFS_EXTRA_SPACE = "0"
IMAGE_OVERHEAD_FACTOR = "1.0"

b/c we also define ramdisk_size=8192 on the kernel cmdline and thus do not support a larger image.

This makes sure we do not exceed the available default ramdisk size.

It avoids:
[    4.400242] RAMDISK: incomplete write (18440 != 32768)
[    4.405466] write error
[    4.456116] EXT4-fs (ram0): bad geometry: block count 12288 exceeds size of device (8192 blocks)