### PR TITLE
Set IMAGE_OVERHEAD_FACTOR for fixed initrd size

### DIFF
--- a/recipes-core/images/initramfs-ostree-image.bb
+++ b/recipes-core/images/initramfs-ostree-image.bb
@@ -24,6 +24,7 @@ IMAGE_ROOTFS_SIZE = "8192"
 # Users will often ask for extra space in their rootfs by setting this
 # globally.  Since this is a initramfs, we don't want to make it bigger
 IMAGE_ROOTFS_EXTRA_SPACE = "0"
+IMAGE_OVERHEAD_FACTOR = "1.0"
 
 BAD_RECOMMENDATIONS += "busybox-syslog"
 


### PR DESCRIPTION
Set 
IMAGE_OVERHEAD_FACTOR = "1.0"

Otherwise the initrd was 12M due to the default overhead (x1.3).