### PR TITLE
scripts/envsetup.sh: Use machine specific local.conf

### DIFF
--- a/scripts/envsetup.sh
+++ b/scripts/envsetup.sh
@@ -24,7 +24,15 @@ fi
 METADIR="${SOURCEDIR}/../.."
 
 if [[ ! -f "${BUILDDIR}/conf/local.conf" ]]; then
-  source "$METADIR/poky/oe-init-build-env" "$BUILDDIR"
+  if [ -z "$TEMPLATECONF" ] && [ -d ${METADIR}/meta-updater-${MACHINE}/conf ]; then
+    # Use the template configurations for the specified machine
+    TEMPLATECONF=${METADIR}/meta-updater-${MACHINE}/conf
+    source "$METADIR/poky/oe-init-build-env" "$BUILDDIR"
+    unset TEMPLATECONF
+  else
+    # Use the default configurations or TEMPLATECONF set by the user
+    source "$METADIR/poky/oe-init-build-env" "$BUILDDIR"
+  fi
   echo "METADIR  := \"\${@os.path.abspath('${METADIR}')}\"" >> conf/bblayers.conf
   cat "${METADIR}/meta-updater/conf/include/bblayers/sota.inc" >> conf/bblayers.conf
   cat "${METADIR}/meta-updater/conf/include/bblayers/sota_${MACHINE}.inc" >> conf/bblayers.conf


### PR DESCRIPTION
Use the configurations for local.conf provided by
layer meta-updater-* (depending on the machine)
if variable TEMPLATECONF has not been set.
Otherwise, if the variable is not set or if the
layer does not provide any configurations then
the default will be used (just as before this change).

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>