### PR TITLE
Add recipes to test pkcs11 functionality in Aktualizr

### DIFF
--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -18,7 +18,7 @@ EXTRA_IMAGEDEPENDS_append_sota = " parted-native mtools-native dosfstools-native
 # Please redefine OSTREE_REPO in order to have a persistent OSTree repo
 OSTREE_REPO ?= "${DEPLOY_DIR_IMAGE}/ostree_repo"
 # For UPTANE operation, OSTREE_BRANCHNAME must start with "${MACHINE}-"
-OSTREE_BRANCHNAME ?= "${MACHINE}-ota"
+OSTREE_BRANCHNAME ?= "${MACHINE}"
 OSTREE_OSNAME ?= "poky"
 OSTREE_INITRAMFS_IMAGE ?= "initramfs-ostree-image"
 

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -7,6 +7,11 @@ LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=9741c346eef56131163e13b9db1241b3"
 DEPENDS = "boost curl openssl jansson libsodium ostree"
 RDEPENDS_${PN} = "lshw"
 
+DEPENDS_append = "${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'hsm', ' libp11', '', d)}"
+
+RDEPENDS_${PN}_append = "${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'hsm', ' engine-pkcs11', '', d)}"
+RDEPENDS_${PN}_append = "${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'hsm-test', ' softhsm softhsm-testtoken', '', d)}"
+
 SRC_URI = " \
   git://github.com/advancedtelematic/aktualizr \
   "

--- a/recipes-support/glib-networking/glib-networking_%.bbappend
+++ b/recipes-support/glib-networking/glib-networking_%.bbappend
@@ -2,5 +2,7 @@ BBCLASSEXTEND_append_sota = " native nativesdk"
 
 # Hackery to prevent relocatable_native_pcfiles from crashing
 do_install_append_class-native () {
-        rmdir ${D}${libdir}/pkgconfig
+	if [ -d ${D}${libdir}/pkgconfig ]; then
+		rmdir ${D}${libdir}/pkgconfig
+	fi
 }

--- a/recipes-support/sc-hsm-embedded/files/0001-Cross-compilation-tweaks.patch
+++ b/recipes-support/sc-hsm-embedded/files/0001-Cross-compilation-tweaks.patch
@@ -1,0 +1,86 @@
+From b6add28acb884b6006216e8422cc18504483c72e Mon Sep 17 00:00:00 2001
+From: Anton Gerasimov <anton@advancedtelematic.com>
+Date: Fri, 8 Sep 2017 15:08:40 +0200
+Subject: [PATCH] Cross-compilation tweaks
+
+---
+ m4/acx_openssl.m4      | 2 ++
+ m4/acx_openssl_ecc.m4  | 3 +++
+ m4/acx_openssl_fips.m4 | 2 ++
+ m4/acx_openssl_gost.m4 | 2 ++
+ 4 files changed, 9 insertions(+)
+
+diff --git a/m4/acx_openssl.m4 b/m4/acx_openssl.m4
+index e90c78f..9de6055 100644
+--- a/m4/acx_openssl.m4
++++ b/m4/acx_openssl.m4
+@@ -25,6 +25,7 @@ AC_DEFUN([ACX_OPENSSL],[
+ 	AC_CHECK_HEADERS([openssl/ssl.h],,[AC_MSG_ERROR([Can't find OpenSSL headers])])
+ 	AC_CHECK_LIB(crypto, BN_new,,[AC_MSG_ERROR([Can't find OpenSSL library])])
+ 
++	if test "$cross_compiling" != yes; then
+ 	AC_MSG_CHECKING([for OpenSSL version])
+ 	CHECK_OPENSSL_VERSION=m4_format(0x%02x%02x%02x000L, $1, $2, $3)
+ 	AC_LANG_PUSH([C])
+@@ -51,6 +52,7 @@ AC_DEFUN([ACX_OPENSSL],[
+ 		AC_MSG_ERROR([OpenSSL library too old ($1.$2.$3 or later required)])
+ 	],[])
+ 	AC_LANG_POP([C])
++	fi
+ 
+ 	CPPFLAGS=$tmp_CPPFLAGS
+ 	LIBS=$tmp_LIBS
+diff --git a/m4/acx_openssl_ecc.m4 b/m4/acx_openssl_ecc.m4
+index 612c505..ba2389d 100644
+--- a/m4/acx_openssl_ecc.m4
++++ b/m4/acx_openssl_ecc.m4
+@@ -1,4 +1,5 @@
+ AC_DEFUN([ACX_OPENSSL_ECC],[
++	if test "$cross_compiling" != yes; then
+ 	AC_MSG_CHECKING(for OpenSSL ECC support)
+ 
+ 	tmp_CPPFLAGS=$CPPFLAGS
+@@ -32,6 +33,8 @@ AC_DEFUN([ACX_OPENSSL_ECC],[
+ 	],[])
+ 	AC_LANG_POP([C])
+ 
++	fi
++
+ 	CPPFLAGS=$tmp_CPPFLAGS
+ 	LIBS=$tmp_LIBS
+ ])
+diff --git a/m4/acx_openssl_fips.m4 b/m4/acx_openssl_fips.m4
+index 0491397..896cdbf 100644
+--- a/m4/acx_openssl_fips.m4
++++ b/m4/acx_openssl_fips.m4
+@@ -1,4 +1,5 @@
+ AC_DEFUN([ACX_OPENSSL_FIPS],[
++	if test "$cross_compiling" != yes; then
+ 	AC_MSG_CHECKING(for OpenSSL FIPS capable library)
+ 
+ 	tmp_CPPFLAGS=$CPPFLAGS
+@@ -47,4 +48,5 @@ AC_DEFUN([ACX_OPENSSL_FIPS],[
+ 
+ 	CPPFLAGS=$tmp_CPPFLAGS
+ 	LIBS=$tmp_LIBS
++	fi
+ ])
+diff --git a/m4/acx_openssl_gost.m4 b/m4/acx_openssl_gost.m4
+index dca489b..34c39d8 100644
+--- a/m4/acx_openssl_gost.m4
++++ b/m4/acx_openssl_gost.m4
+@@ -1,4 +1,5 @@
+ AC_DEFUN([ACX_OPENSSL_GOST],[
++	if test "$cross_compiling" != yes; then
+ 	AC_MSG_CHECKING(for OpenSSL GOST support)
+ 
+ 	tmp_CPPFLAGS=$CPPFLAGS
+@@ -62,4 +63,5 @@ AC_DEFUN([ACX_OPENSSL_GOST],[
+ 
+ 	CPPFLAGS=$tmp_CPPFLAGS
+ 	LIBS=$tmp_LIBS
++	fi
+ ])
+-- 
+2.7.4
+

--- a/recipes-support/sc-hsm-embedded/sc-hsm-embedded_git.bb
+++ b/recipes-support/sc-hsm-embedded/sc-hsm-embedded_git.bb
@@ -1,0 +1,22 @@
+SUMMARY = "Smartcard HSM driver"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://COPYING;md5=55b854a477953696452f698a3af5de1c"
+
+inherit autotools-brokensep
+
+
+SRC_URI = "git://github.com/CardContact/sc-hsm-embedded.git;branch=master"
+SRCREV="a45155d4249575ebdfb16ff26fdedbc4c4813002"
+
+S = "${WORKDIR}/git"
+
+DEPENDS += " openssl pcsc-lite"
+
+do_configure() {
+ autoreconf -fi
+ oe_runconf
+}
+
+FILES_${PN} += "${libdir}"
+FILES_SOLIBSDEV = ""
+

--- a/recipes-support/softhsm-testtoken/files/createtoken.service
+++ b/recipes-support/softhsm-testtoken/files/createtoken.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Create a mock smartcard for testing
+Before=aktualizr.service
+RequiredBy=aktualizr.service
+
+[Service]
+RestartSec=10
+Restart=on-failure
+ExecStart=/usr/bin/createtoken.sh
+
+[Install]
+WantedBy=aktualizr.service

--- a/recipes-support/softhsm-testtoken/files/createtoken.sh
+++ b/recipes-support/softhsm-testtoken/files/createtoken.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+if pkcs11-tool --module=/usr/lib/softhsm/libsofthsm2.so -O; then
+	# The token has already been initialized, exit
+	exit 0
+fi
+
+if ! ls /var/sota/token/pkey.pem /var/sota/token/client.pem; then
+	# Key/certificate pair is not present, repeat
+	mkdir -p /var/sota/token
+	exit 1
+fi
+
+mkdir -p /var/lib/softhsm/tokens
+softhsm2-util --init-token --slot 0 --label "Virtual token" --pin 1234 --so-pin 1234
+
+pkcs11-tool --module=/usr/lib/softhsm/libsofthsm2.so --label 'Virtual token' --write-object /var/sota/token/pkey.pem --type privkey --login --pin 1234
+openssl x509 -outform der -in /var/sota/token/client.pem -out /var/sota/token/client.der
+pkcs11-tool --module=/usr/lib/softhsm/libsofthsm2.so --label 'Virtual token' --write-object /var/sota/token/client.der --type cert --login --pin 1234
+
+exit 0

--- a/recipes-support/softhsm-testtoken/softhsm-testtoken.bb
+++ b/recipes-support/softhsm-testtoken/softhsm-testtoken.bb
@@ -1,0 +1,27 @@
+SUMMARY = "Mock smartcard for aktualizr"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690 \
+                    file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+
+
+inherit systemd
+
+RDEPENDS_${PN} = "softhsm libp11"
+DEPENDS_append = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', ' systemd', '', d)}"
+
+
+SRC_URI = "file://createtoken.service \
+	   file://createtoken.sh"
+
+SYSTEMD_SERVICE_${PN} = "createtoken.service"
+
+do_install() {
+  install -d ${D}${systemd_unitdir}/system
+  install -m 0644 ${WORKDIR}/createtoken.service ${D}${systemd_unitdir}/system/createtoken.service
+  install -d ${D}${bindir}
+  install -m 0744 ${WORKDIR}/createtoken.sh ${D}${bindir}/createtoken.sh
+}
+
+FILES_${PN} = "${bindir}/createtoken.sh \
+	       ${systemd_unitdir}/system/createtoken.service"
+

--- a/recipes-support/softhsm/files/0001-Cross-compilation-tweaks.patch
+++ b/recipes-support/softhsm/files/0001-Cross-compilation-tweaks.patch
@@ -1,0 +1,86 @@
+From b6add28acb884b6006216e8422cc18504483c72e Mon Sep 17 00:00:00 2001
+From: Anton Gerasimov <anton@advancedtelematic.com>
+Date: Fri, 8 Sep 2017 15:08:40 +0200
+Subject: [PATCH] Cross-compilation tweaks
+
+---
+ m4/acx_openssl.m4      | 2 ++
+ m4/acx_openssl_ecc.m4  | 3 +++
+ m4/acx_openssl_fips.m4 | 2 ++
+ m4/acx_openssl_gost.m4 | 2 ++
+ 4 files changed, 9 insertions(+)
+
+diff --git a/m4/acx_openssl.m4 b/m4/acx_openssl.m4
+index e90c78f..9de6055 100644
+--- a/m4/acx_openssl.m4
++++ b/m4/acx_openssl.m4
+@@ -25,6 +25,7 @@ AC_DEFUN([ACX_OPENSSL],[
+ 	AC_CHECK_HEADERS([openssl/ssl.h],,[AC_MSG_ERROR([Can't find OpenSSL headers])])
+ 	AC_CHECK_LIB(crypto, BN_new,,[AC_MSG_ERROR([Can't find OpenSSL library])])
+ 
++	if test "$cross_compiling" != yes; then
+ 	AC_MSG_CHECKING([for OpenSSL version])
+ 	CHECK_OPENSSL_VERSION=m4_format(0x%02x%02x%02x000L, $1, $2, $3)
+ 	AC_LANG_PUSH([C])
+@@ -51,6 +52,7 @@ AC_DEFUN([ACX_OPENSSL],[
+ 		AC_MSG_ERROR([OpenSSL library too old ($1.$2.$3 or later required)])
+ 	],[])
+ 	AC_LANG_POP([C])
++	fi
+ 
+ 	CPPFLAGS=$tmp_CPPFLAGS
+ 	LIBS=$tmp_LIBS
+diff --git a/m4/acx_openssl_ecc.m4 b/m4/acx_openssl_ecc.m4
+index 612c505..ba2389d 100644
+--- a/m4/acx_openssl_ecc.m4
++++ b/m4/acx_openssl_ecc.m4
+@@ -1,4 +1,5 @@
+ AC_DEFUN([ACX_OPENSSL_ECC],[
++	if test "$cross_compiling" != yes; then
+ 	AC_MSG_CHECKING(for OpenSSL ECC support)
+ 
+ 	tmp_CPPFLAGS=$CPPFLAGS
+@@ -32,6 +33,8 @@ AC_DEFUN([ACX_OPENSSL_ECC],[
+ 	],[])
+ 	AC_LANG_POP([C])
+ 
++	fi
++
+ 	CPPFLAGS=$tmp_CPPFLAGS
+ 	LIBS=$tmp_LIBS
+ ])
+diff --git a/m4/acx_openssl_fips.m4 b/m4/acx_openssl_fips.m4
+index 0491397..896cdbf 100644
+--- a/m4/acx_openssl_fips.m4
++++ b/m4/acx_openssl_fips.m4
+@@ -1,4 +1,5 @@
+ AC_DEFUN([ACX_OPENSSL_FIPS],[
++	if test "$cross_compiling" != yes; then
+ 	AC_MSG_CHECKING(for OpenSSL FIPS capable library)
+ 
+ 	tmp_CPPFLAGS=$CPPFLAGS
+@@ -47,4 +48,5 @@ AC_DEFUN([ACX_OPENSSL_FIPS],[
+ 
+ 	CPPFLAGS=$tmp_CPPFLAGS
+ 	LIBS=$tmp_LIBS
++	fi
+ ])
+diff --git a/m4/acx_openssl_gost.m4 b/m4/acx_openssl_gost.m4
+index dca489b..34c39d8 100644
+--- a/m4/acx_openssl_gost.m4
++++ b/m4/acx_openssl_gost.m4
+@@ -1,4 +1,5 @@
+ AC_DEFUN([ACX_OPENSSL_GOST],[
++	if test "$cross_compiling" != yes; then
+ 	AC_MSG_CHECKING(for OpenSSL GOST support)
+ 
+ 	tmp_CPPFLAGS=$CPPFLAGS
+@@ -62,4 +63,5 @@ AC_DEFUN([ACX_OPENSSL_GOST],[
+ 
+ 	CPPFLAGS=$tmp_CPPFLAGS
+ 	LIBS=$tmp_LIBS
++	fi
+ ])
+-- 
+2.7.4
+

--- a/recipes-support/softhsm/softhsm_git.bb
+++ b/recipes-support/softhsm/softhsm_git.bb
@@ -1,0 +1,27 @@
+SUMMARY = "HSM emulator"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=ef3f77a3507c3d91e75b9f2bdaee4210"
+
+inherit autotools-brokensep
+
+
+SRC_URI = "git://github.com/opendnssec/SoftHSMv2.git;branch=master \
+	   file://0001-Cross-compilation-tweaks.patch"
+SRCREV="1f7498c0c65b1b1ad5e1bdbd87e9d4b100705745"
+
+S = "${WORKDIR}/git"
+
+DEPENDS += " openssl"
+
+EXTRA_OECONF = "--disable-gost --with-openssl=${STAGING_LIBDIR}/.."
+
+do_configure() {
+ unset docdir
+ sh ./autogen.sh
+ oe_runconf
+}
+
+FILES_${PN} = "${bindir} \
+	       ${libdir}/softhsm \
+	       ${sysconfdir} \
+	       ${localstatedir}/lib/softhsm "


### PR DESCRIPTION
Also introduces SOTA_CLIENT_FEATURES variable which should control client's functionality. E.g. SOTA_CLIENT_FEATURES = "hsm hsm-test" to add HSM support and create a mock HSM token for testing.
HSM support inside aktualizr itself is coming once tested.