### PR TITLE
Hacky ability to provide client credentials and install them on the device

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -146,6 +146,25 @@ IMAGE_CMD_ostree () {
 		cp ${SOTA_SECONDARY_ECUS} var/sota/ecus
 	fi
 
+	# Deploy client certificate and key.
+	if [ -n "${SOTA_CLIENT_CERTIFICATE}" ]; then
+		if [ -e ${SOTA_CLIENT_CERTIFICATE} ]; then
+			mkdir -p var/sota/token
+			cp ${SOTA_CLIENT_CERTIFICATE} var/sota/token/
+		fi
+	fi
+	if [ -n "${SOTA_CLIENT_KEY}" ]; then
+		if [ -e ${SOTA_CLIENT_KEY} ]; then
+			mkdir -p var/sota/token
+			cp ${SOTA_CLIENT_KEY} var/sota/token/
+		fi
+	fi
+	if [ -n "${SOTA_ROOT_CA}" ]; then
+		if [ -e ${SOTA_ROOT_CA} ]; then
+			cp ${SOTA_ROOT_CA} var/sota/
+		fi
+	fi
+
 	# Creating boot directories is required for "ostree admin deploy"
 
 	mkdir -p boot/loader.0


### PR DESCRIPTION
Quick fix to maybe make @OYTIS's life easier.

I recommend pointing the necessary variables to the output directory created from running cert_provider with -d so that you can quickly regenerate the credentials at will.

I also recognize that I may have put this change in a less than ideal location. Please advise if there is a better organizational strategy. I'm still learning this side of things.