### PR TITLE
Support pkcs#11 in aktualizr and add softhsm token for testing

### DIFF
--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -11,6 +11,9 @@ IMAGE_INSTALL_append_sota = " ostree os-release ${SOTA_CLIENT} ${SOTA_CLIENT_PRO
 IMAGE_CLASSES += " image_types_ostree image_types_ota"
 IMAGE_FSTYPES += "${@bb.utils.contains('DISTRO_FEATURES', 'sota', 'ostreepush otaimg wic', ' ', d)}"
 
+PACKAGECONFIG_append_pn-curl = "${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'hsm', " ssl", " ", d)}"
+PACKAGECONFIG_remove_pn-curl = "${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'hsm', " gnutls", " ", d)}"
+
 WKS_FILE_sota ?= "sdimage-sota.wks"
 
 EXTRA_IMAGEDEPENDS_append_sota = " parted-native mtools-native dosfstools-native"

--- a/recipes-sota/aktualizr/aktualizr-hsm-test-prov.bb
+++ b/recipes-sota/aktualizr/aktualizr-hsm-test-prov.bb
@@ -1,0 +1,34 @@
+SUMMARY = "Aktualizr systemd service and configuration with HSM support"
+DESCRIPTION = "Systemd service and configurations for Aktualizr, the SOTA Client application written in C++"
+HOMEPAGE = "https://github.com/advancedtelematic/aktualizr"
+SECTION = "base"
+LICENSE = "MPL-2.0"
+LIC_FILES_CHKSUM = "file://${WORKDIR}/LICENSE;md5=9741c346eef56131163e13b9db1241b3"
+
+DEPENDS = "aktualizr-native"
+RDEPENDS_${PN} = "aktualizr"
+
+SRC_URI = " \
+  file://LICENSE \
+  file://aktualizr-autoprovision.service \
+  file://sota_hsm_test.toml \
+  "
+PV = "1.0"
+PR = "6"
+
+SYSTEMD_SERVICE_${PN} = "aktualizr.service"
+
+inherit systemd
+
+do_install() {
+    install -d ${D}/${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/aktualizr-autoprovision.service ${D}/${systemd_unitdir}/system/aktualizr.service
+    install -d ${D}/usr/lib/sota
+    aktualizr_implicit_writer -c ${SOTA_PACKED_CREDENTIALS} --no-root-ca \
+        -i ${WORKDIR}/sota_hsm_test.toml -o ${D}/usr/lib/sota/sota.toml -p ${D}
+}
+
+FILES_${PN} = " \
+                ${systemd_unitdir}/system/aktualizr.service \
+                /usr/lib/sota/sota.toml \
+                "

--- a/recipes-sota/aktualizr/aktualizr_common.inc
+++ b/recipes-sota/aktualizr/aktualizr_common.inc
@@ -11,7 +11,7 @@ PR = "7"
 SRC_URI = " \
   git://github.com/advancedtelematic/aktualizr;branch=${BRANCH} \
   "
-SRCREV = "ed2c9684d3b7e605b41a3e7dda0afded1d4a084c"
+SRCREV = "c38a1fd990cf238de2912db4d7023ddd91e2131f"
 BRANCH ?= "master"
 
 S = "${WORKDIR}/git"

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -9,7 +9,7 @@ RDEPENDS_${PN}_append = "${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'hsm-test'
 
 inherit systemd
 
-EXTRA_OECMAKE = "-DWARNING_AS_ERROR=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_OSTREE=ON -DAKTUALIZR_VERSION=${PV}"
+EXTRA_OECMAKE = "-DWARNING_AS_ERROR=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_OSTREE=ON ${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'hsm', '-DBUILD_P11=ON', '', d)} -DAKTUALIZR_VERSION=${PV}"
 
 do_install_append () {
     rm ${D}${bindir}/aktualizr_cert_provider

--- a/recipes-sota/aktualizr/files/sota_hsm_test.toml
+++ b/recipes-sota/aktualizr/files/sota_hsm_test.toml
@@ -1,0 +1,17 @@
+[tls]
+certificates_directory = "/var/sota/"
+ca_file = "/var/sota/token/root.crt"
+client_certificate = "01"
+cert_source = "pkcs11"
+pkey_file = "02"
+pkey_source = "pkcs11"
+
+[p11]
+module = "/usr/lib/softhsm/libsofthsm2.so"
+pass = "1234"
+
+[uptane]
+metadata_path = "/var/sota/metadata"
+private_key_path = "ecukey.der"
+public_key_path = "ecukey.pub"
+

--- a/recipes-sota/ostree/ostree_git.bb
+++ b/recipes-sota/ostree/ostree_git.bb
@@ -8,9 +8,9 @@ INHERIT_remove_class-native = "systemd"
 
 SRC_URI = "gitsm://github.com/ostreedev/ostree.git;branch=master"
 
-SRCREV="3b09620c2738bce4ed45e099cf2e4c5df7671d39"
+SRCREV="e3c3ec5dd91492e82c79223052443d038c60f41c"
 
-PV = "2017.3-31-g3b09620c"
+PV = "v2017.11-20-ge3c3ec5d"
 
 S = "${WORKDIR}/git"
 
@@ -79,6 +79,9 @@ FILES_${PN} += " \
     ${datadir}/gir-1.0/OSTree-1.0.gir \
     ${libdir}/girepository-1.0 \
     ${libdir}/girepository-1.0/OSTree-1.0.typelib \
+    ${libdir}/tmpfiles.d/ostree-tmpfiles.conf \
+    ${datadir}/bash-completion/completions/ostree \
+    ${systemd_unitdir}/system-generators/ostree-system-generator \
 "
 
 PACKAGES =+ "${PN}-switchroot"

--- a/recipes-support/softhsm-testtoken/files/createtoken.sh
+++ b/recipes-support/softhsm-testtoken/files/createtoken.sh
@@ -5,17 +5,22 @@ if pkcs11-tool --module=/usr/lib/softhsm/libsofthsm2.so -O; then
 	exit 0
 fi
 
-if ! ls /var/sota/token/pkey.pem /var/sota/token/client.pem; then
+if ! ls /var/sota/token/pkey.pem /var/sota/token/client.pem /var/sota/token/pkey.pem; then
 	# Key/certificate pair is not present, repeat
-	mkdir -p /var/sota/token
 	exit 1
 fi
 
 mkdir -p /var/lib/softhsm/tokens
 softhsm2-util --init-token --slot 0 --label "Virtual token" --pin 1234 --so-pin 1234
 
-pkcs11-tool --module=/usr/lib/softhsm/libsofthsm2.so --label 'Virtual token' --write-object /var/sota/token/pkey.pem --type privkey --login --pin 1234
+softhsm2-util --import /var/sota/token/pkey.pem --label "pkey" --id 02 --token 'Virtual token' --pin 1234
 openssl x509 -outform der -in /var/sota/token/client.pem -out /var/sota/token/client.der
-pkcs11-tool --module=/usr/lib/softhsm/libsofthsm2.so --label 'Virtual token' --write-object /var/sota/token/client.der --type cert --login --pin 1234
+pkcs11-tool --module=/usr/lib/softhsm/libsofthsm2.so --id 1 --write-object /var/sota/token/client.der --type cert --login --pin 1234
+
+# Import UPTANE keypair if it exists
+if [ -f /var/sota/token/ecukey.pem ]; then
+	openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in /var/sota/token/ecukey.pem -out /var/sota/token/ecukey.p8
+	softhsm2-util --import /var/sota/token/ecukey.p8 --label "uptanekey" --id 03 --token 'Virtual token' --pin 1234
+fi
 
 exit 0


### PR DESCRIPTION
Credentials triple (client.pem, pkey.pem, root.crt) should be placed in /var/sota/token after the build or on the running image. A convenient way to do it is by using cert_provider:

```
aktualizr_cert_provider -r -c /path/to/credentials -d /path/to/var/sota/token
```