### PR TITLE
Remove IMAGEDATESTAMP to make sstate input deterministic (morty)

### DIFF
--- a/classes/sdcard_image-rpi-ota.bbclass
+++ b/classes/sdcard_image-rpi-ota.bbclass
@@ -73,10 +73,6 @@ SDIMG_OTA = "${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.rpi-sdimg-ota"
 # Additional files and/or directories to be copied into the vfat partition from the IMAGE_ROOTFS.
 FATPAYLOAD ?= ""
 
-IMAGEDATESTAMP = "${@time.strftime('%Y.%m.%d',time.gmtime())}"
-IMAGE_CMD_rpi-sdimg-ota[vardepsexclude] += "IMAGEDATESTAMP"
-IMAGE_CMD_rpi-sdimg-ota[vardepsexclude] += "DATETIME"
-
 IMAGE_CMD_rpi-sdimg-ota () {
 
 	# Align partitions
@@ -151,7 +147,7 @@ IMAGE_CMD_rpi-sdimg-ota () {
 	fi
 
 	# Add stamp file
-	echo "${IMAGE_NAME}-${IMAGEDATESTAMP}" > ${WORKDIR}/image-version-info
+	echo "${IMAGE_NAME}" > ${WORKDIR}/image-version-info
 	mcopy -i ${WORKDIR}/boot.img -v ${WORKDIR}//image-version-info ::
 
 	# Burn Partitions


### PR DESCRIPTION
Branch name can be misleading, because the PR doesn't cover the initramfs case, we need to collect more info to fix that.