### PR TITLE
Share /run directory between initramfs and system image to communicate ostree-booted file

### DIFF
--- a/recipes-sota/ostree-initrd/files/init.sh
+++ b/recipes-sota/ostree-initrd/files/init.sh
@@ -67,7 +67,7 @@ ostree-prepare-root /sysroot
 
 # move mounted devices to new root
 cd /sysroot
-for x in dev proc; do
+for x in dev proc run; do
 	log_info "Moving /$x to new rootfs"
 	mount -o move "/$x" "$x"
 done


### PR DESCRIPTION
Yes, this fixes PRO-4249