### PR TITLE
Bump ostree version to get Shaun's fix.

### DIFF
--- a/recipes-sota/ostree/ostree_git.bb
+++ b/recipes-sota/ostree/ostree_git.bb
@@ -8,9 +8,9 @@ INHERIT_remove_class-native = "systemd"
 
 SRC_URI = "gitsm://github.com/ostreedev/ostree.git;branch=master"
 
-SRCREV="e3c3ec5dd91492e82c79223052443d038c60f41c"
+SRCREV="ae61321046ad7f4148a5884c8c6c8b2594ff840e"
 
-PV = "v2017.11-20-ge3c3ec5d"
+PV = "v2017.13"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Unnecessary error messages have been silenced by skipping some checks
that weren't necessary in our case.