### PR TITLE
Copy repo manifest to the device.

### DIFF
--- a/classes/image_repo_manifest.bbclass
+++ b/classes/image_repo_manifest.bbclass
@@ -1,0 +1,23 @@
+# Writes the repo manifest to the target filesystem in /etc/manifest.xml
+#
+# Author: Phil Wise <phil@advancedtelematic.com>
+# Usage: add "inherit image_repo_manifest" to your image file
+# To reproduce a build, copy the /etc/manifest.xml to .repo/manifests/yourname.xml
+# then run:
+# repo init -m yourname.xml
+# repo sync
+# For more information, see:
+# https://web.archive.org/web/20161224194009/https://wiki.cyanogenmod.org/w/Doc:_Using_manifests 
+
+HOSTTOOLS_NONFATAL += " repo "
+
+# Write build information to target filesystem
+buildinfo () {
+  if [ $(which repo) ]; then
+    repo manifest --revision-as-HEAD -o ${IMAGE_ROOTFS}${sysconfdir}/manifest.xml
+  else
+    echo "Android repo tool not food; manifest not copied."
+  fi
+}
+
+IMAGE_PREPROCESS_COMMAND += "buildinfo;"

--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -35,3 +35,5 @@ SOTA_MACHINE_qemux86-64 ?= "qemux86-64"
 SOTA_MACHINE_am335x-evm ?= "am335x-evm-wifi"
 
 inherit sota_${SOTA_MACHINE}
+
+inherit image_repo_manifest


### PR DESCRIPTION
Helpful for debugging, etc.

Mostly copied from here:
https://github.com/openivimobility/meta-oim/blob/master/classes/image-repo-manifest.bbclass

Does not require repo to be installed on the host. If it isn't, the manifest simply isn't copied. Although if you're using meta-updater, you probably should have repo...