### PR TITLE
Delete hsm-test SOTA_CLIENT_FEATURE as redundant and provoking mistakes

### DIFF
--- a/recipes-sota/aktualizr/aktualizr-hsm-test-prov.bb
+++ b/recipes-sota/aktualizr/aktualizr-hsm-test-prov.bb
@@ -6,7 +6,7 @@ LICENSE = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/LICENSE;md5=9741c346eef56131163e13b9db1241b3"
 
 DEPENDS = "aktualizr-native"
-RDEPENDS_${PN} = "aktualizr"
+RDEPENDS_${PN} = "aktualizr softhsm softhsm-testtoken"
 
 SRC_URI = " \
   file://LICENSE \

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -11,7 +11,6 @@ DEPENDS_append_class-native = "glib-2.0-native "
 
 RDEPENDS_${PN}_class-target = "lshw "
 RDEPENDS_${PN}_append_class-target = "${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'hsm', ' engine-pkcs11', '', d)} "
-RDEPENDS_${PN}_append_class-target = "${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'hsm-test', ' softhsm softhsm-testtoken', '', d)} "
 
 PV = "1.0+git${SRCPV}"
 PR = "7"


### PR DESCRIPTION
hsm-test feature requires aktualizr-hsm-test-prov in order to work properly and vice versa, so it's basically useless.