### PR TITLE
Ignore configuration templates to avoid duplicate inclusion of stuff

### DIFF
--- a/classes/sota_qemux86-64.bbclass
+++ b/classes/sota_qemux86-64.bbclass
@@ -9,3 +9,5 @@ UBOOT_MACHINE_sota = "qemu-x86_defconfig"
 OSTREE_BOOTLOADER ?= "u-boot"
 
 OSTREE_KERNEL_ARGS ?= "ramdisk_size=16384 rw rootfstype=ext4 rootwait rootdelay=2 ostree_root=/dev/hda"
+
+IMAGE_ROOTFS_EXTRA_SPACE = "${@bb.utils.contains('DISTRO_FEATURES', 'sota', '65536', '', d)}"

--- a/scripts/envsetup.sh
+++ b/scripts/envsetup.sh
@@ -24,15 +24,7 @@ fi
 METADIR="${SOURCEDIR}/../.."
 
 if [[ ! -f "${BUILDDIR}/conf/local.conf" ]]; then
-  if [ -z "$TEMPLATECONF" ] && [ -d ${METADIR}/meta-updater-${MACHINE}/conf ]; then
-    # Use the template configurations for the specified machine
-    TEMPLATECONF=${METADIR}/meta-updater-${MACHINE}/conf
-    source "$METADIR/poky/oe-init-build-env" "$BUILDDIR"
-    unset TEMPLATECONF
-  else
-    # Use the default configurations or TEMPLATECONF set by the user
-    source "$METADIR/poky/oe-init-build-env" "$BUILDDIR"
-  fi
+  source "$METADIR/poky/oe-init-build-env" "$BUILDDIR"
   echo "METADIR  := \"\${@os.path.abspath('${METADIR}')}\"" >> conf/bblayers.conf
   cat "${METADIR}/meta-updater/conf/include/bblayers/sota.inc" >> conf/bblayers.conf
   cat "${METADIR}/meta-updater/conf/include/bblayers/sota_${MACHINE}.inc" >> conf/bblayers.conf


### PR DESCRIPTION
Also add IMAGE_ROOTFS_EXTRA_SPACE to qemu configuration which was
the original motivation for returning TEMPLATECONF processing (see
https://github.com/advancedtelematic/meta-updater-qemux86-64/pull/9 )