### PR TITLE
Fix builds outside the .repo directory

### DIFF
--- a/classes/image_repo_manifest.bbclass
+++ b/classes/image_repo_manifest.bbclass
@@ -14,9 +14,9 @@ HOSTTOOLS_NONFATAL += " repo "
 # Write build information to target filesystem
 buildinfo () {
   if [ $(which repo) ]; then
-    repo manifest --revision-as-HEAD -o ${IMAGE_ROOTFS}${sysconfdir}/manifest.xml
+    repo manifest --revision-as-HEAD -o ${IMAGE_ROOTFS}${sysconfdir}/manifest.xml || echo "Android repo tool failed to run; manifest not copied"
   else
-    echo "Android repo tool not food; manifest not copied."
+    echo "Android repo tool not found; manifest not copied."
   fi
 }
 


### PR DESCRIPTION
The repo tool searches up the directory tree to find the .repo directory.
Cleanly handle the case where it can't find anything.