### PR TITLE
Add spaces before "_append" clauses

### DIFF
--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -28,8 +28,8 @@ inherit cmake
 BBCLASSEXTEND =+ "native"
 
 EXTRA_OECMAKE = "-DWARNING_AS_ERROR=OFF -DCMAKE_BUILD_TYPE=Release -DAKTUALIZR_VERSION=${PV} "
-EXTRA_OECMAKE_append_class-target = "-DBUILD_OSTREE=ON ${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'hsm', '-DBUILD_P11=ON', '', d)} "
-EXTRA_OECMAKE_append_class-native = "-DBUILD_SOTA_TOOLS=ON -DBUILD_OSTREE=OFF "
+EXTRA_OECMAKE_append_class-target = " -DBUILD_OSTREE=ON ${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'hsm', '-DBUILD_P11=ON', '', d)} "
+EXTRA_OECMAKE_append_class-native = " -DBUILD_SOTA_TOOLS=ON -DBUILD_OSTREE=OFF "
 
 do_install_append () {
     rm -f ${D}${bindir}/aktualizr_cert_provider


### PR DESCRIPTION
Under some conditions missing space can lead to a corrupted environment variable