### PR TITLE
Minor fixes and cleanup.

### DIFF
--- a/lib/oeqa/selftest/updater.py
+++ b/lib/oeqa/selftest/updater.py
@@ -51,7 +51,7 @@ class GarageSignTests(oeSelfTest):
 class HsmTests(oeSelfTest):
 
     def test_hsm(self):
-        self.write_config('SOTA_CLIENT_FEATURES="hsm hsm-test"')
+        self.write_config('SOTA_CLIENT_FEATURES="hsm"')
         bitbake('core-image-minimal')
 
 

--- a/recipes-sota/aktualizr/aktualizr-auto-prov.bb
+++ b/recipes-sota/aktualizr/aktualizr-auto-prov.bb
@@ -43,13 +43,13 @@ do_install() {
 
       # deploy SOTA credentials
       if [ -e ${SOTA_PACKED_CREDENTIALS} ]; then
-          cp ${SOTA_PACKED_CREDENTIALS} ${D}/var/sota/sota_provisioning_credentials.zip
+          cp ${SOTA_PACKED_CREDENTIALS} ${D}${localstatedir}/sota/sota_provisioning_credentials.zip
           # Device should not be able to push data to treehub
-          zip -d ${D}/var/sota/sota_provisioning_credentials.zip treehub.json
+          zip -d ${D}${localstatedir}/sota/sota_provisioning_credentials.zip treehub.json
       fi
     fi
-    install -d ${D}/${systemd_unitdir}/system
-    install -m 0644 ${WORKDIR}/aktualizr.service ${D}/${systemd_unitdir}/system/aktualizr.service
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/aktualizr.service ${D}${systemd_unitdir}/system/aktualizr.service
 }
 
 FILES_${PN} = " \

--- a/recipes-sota/aktualizr/aktualizr-hsm-test-prov.bb
+++ b/recipes-sota/aktualizr/aktualizr-hsm-test-prov.bb
@@ -22,11 +22,11 @@ inherit systemd
 require environment.inc
 
 do_install() {
-    install -d ${D}/${systemd_unitdir}/system
-    install -m 0644 ${WORKDIR}/aktualizr.service ${D}/${systemd_unitdir}/system/aktualizr.service
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/aktualizr.service ${D}${systemd_unitdir}/system/aktualizr.service
     install -d ${D}${libdir}/sota
     aktualizr_implicit_writer -c ${SOTA_PACKED_CREDENTIALS} --no-root-ca \
-        -i ${STAGING_DIR_NATIVE}/${libdir}/sota/sota_hsm_test.toml -o ${D}${libdir}/sota/sota.toml -p ${D}
+        -i ${STAGING_DIR_NATIVE}${libdir}/sota/sota_hsm_test.toml -o ${D}${libdir}/sota/sota.toml -p ${D}
 }
 
 FILES_${PN} = " \

--- a/recipes-sota/aktualizr/aktualizr-implicit-prov.bb
+++ b/recipes-sota/aktualizr/aktualizr-implicit-prov.bb
@@ -21,11 +21,11 @@ inherit systemd
 require environment.inc
 
 do_install() {
-    install -d ${D}/${systemd_unitdir}/system
-    install -m 0644 ${WORKDIR}/aktualizr.service ${D}/${systemd_unitdir}/system/aktualizr.service
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/aktualizr.service ${D}${systemd_unitdir}/system/aktualizr.service
     install -d ${D}${libdir}/sota
     aktualizr_implicit_writer -c ${SOTA_PACKED_CREDENTIALS} \
-        -i ${STAGING_DIR_NATIVE}/${libdir}/sota/sota_implicit_prov.toml -o ${D}${libdir}/sota/sota.toml -p ${D}
+        -i ${STAGING_DIR_NATIVE}${libdir}/sota/sota_implicit_prov.toml -o ${D}${libdir}/sota/sota.toml -p ${D}
 }
 
 FILES_${PN} = " \

--- a/recipes-sota/garage-sign/garage-sign.bb
+++ b/recipes-sota/garage-sign/garage-sign.bb
@@ -27,8 +27,7 @@ do_install() {
 }
 
 FILES_${PN} = " \
-  /usr/bin \
-  /usr/bin/garage-sign.bat \
-  /usr/bin/garage-sign \
-  /usr/lib/* \
+  ${bindir}/garage-sign.bat \
+  ${bindir}/garage-sign \
+  ${libdir}/* \
   "

--- a/recipes-support/ca-certificates/ca-certificates_%.bbappend
+++ b/recipes-support/ca-certificates/ca-certificates_%.bbappend
@@ -1,1 +1,1 @@
-SYSROOT_DIRS += "/etc"
+SYSROOT_DIRS += "${sysconfdir}"


### PR DESCRIPTION
* hsm-test is no longer used.
* Use Yocto variables where suitable.
* Eliminate redundant directory slashes.