### PR TITLE
Install /var/sota.

### DIFF
--- a/recipes-sota/aktualizr/aktualizr-auto-prov.bb
+++ b/recipes-sota/aktualizr/aktualizr-auto-prov.bb
@@ -39,9 +39,7 @@ do_install() {
     install -d ${D}${libdir}/sota
     install -d ${D}${localstatedir}/sota
     if [ -n "${SOTA_PACKED_CREDENTIALS}" ]; then
-        install -d ${D}/${systemd_unitdir}/system
-        install -m 0644 ${WORKDIR}/aktualizr.service ${D}/${systemd_unitdir}/system/aktualizr.service
-        install -m "0644" ${STAGING_DIR_NATIVE}/${libdir}/sota/sota_autoprov.toml ${D}${libdir}/sota/sota.toml
+      install -m 0644 ${STAGING_DIR_NATIVE}/${libdir}/sota/sota_autoprov.toml ${D}${libdir}/sota/sota.toml
 
       # deploy SOTA credentials
       if [ -e ${SOTA_PACKED_CREDENTIALS} ]; then
@@ -49,14 +47,14 @@ do_install() {
           # Device should not be able to push data to treehub
           zip -d ${D}/var/sota/sota_provisioning_credentials.zip treehub.json
       fi
-    else
-        install -d ${D}/${systemd_unitdir}/system
-        install -m 0644 ${WORKDIR}/aktualizr.service ${D}/${systemd_unitdir}/system/aktualizr.service
     fi
+    install -d ${D}/${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/aktualizr.service ${D}/${systemd_unitdir}/system/aktualizr.service
 }
 
 FILES_${PN} = " \
                 ${systemd_unitdir}/system/aktualizr.service \
                 ${libdir}/sota/sota.toml \
+                ${localstatedir}/sota \
                 ${localstatedir}/sota/sota_provisioning_credentials.zip \
                 "


### PR DESCRIPTION
If not using SOTA_PROVISIONING_CREDENTIALS, nothing is written to /var/sota but it is still created. Quick fix: install it.

We could instead not create /var/sota at all, but since we seem to use it all the time, it's not a bad thing just to make it and leave it empty.

I also fixed an issue where we were doing the same thing in both the if and else clause. DRY.

This issue was found by @jochenschneider and hopefully fixes all his troubles.