### PR TITLE
Fix variable expansion problem when SOTA_PACKED_CREDENTIALS is not set.

### DIFF
--- a/recipes-sota/aktualizr/credentials.inc
+++ b/recipes-sota/aktualizr/credentials.inc
@@ -1,1 +1,1 @@
-SRC_URI_append = "${@'file://${SOTA_PACKED_CREDENTIALS}' if d.getVar('SOTA_PACKED_CREDENTIALS', True) else ' '}"
+SRC_URI_append = "${@('file://' + d.getVar('SOTA_PACKED_CREDENTIALS', True)) if d.getVar('SOTA_PACKED_CREDENTIALS', True) else ''}"


### PR DESCRIPTION
Reported by Stevan, traced to the problem by me, actually fixed by Anton.

Note that this does NOT entirely fix bitbaking for implicit provisioning without `SOTA_PACKED_CREDENTIALS`.