### PR TITLE
Don't run implicit_writer if SOTA_PACKED_CREDENTIALS is not set.

### DIFF
--- a/recipes-sota/aktualizr/aktualizr-implicit-prov.bb
+++ b/recipes-sota/aktualizr/aktualizr-implicit-prov.bb
@@ -25,8 +25,10 @@ do_install() {
     install -d ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/aktualizr.service ${D}${systemd_unitdir}/system/aktualizr.service
     install -d ${D}${libdir}/sota
-    aktualizr_implicit_writer -c ${SOTA_PACKED_CREDENTIALS} \
-        -i ${STAGING_DIR_NATIVE}${libdir}/sota/sota_implicit_prov.toml -o ${D}${libdir}/sota/sota.toml -p ${D}
+    if [ -n "${SOTA_PACKED_CREDENTIALS}" ]; then
+        aktualizr_implicit_writer -c ${SOTA_PACKED_CREDENTIALS} \
+            -i ${STAGING_DIR_NATIVE}${libdir}/sota/sota_implicit_prov.toml -o ${D}${libdir}/sota/sota.toml -p ${D}
+    fi
 }
 
 FILES_${PN} = " \


### PR DESCRIPTION
This basically cripples implicit provisioning but at least it bitbakes
without error.