### PR TITLE
sota_qemux86-64.bbclass: Use u-boot-ota

### DIFF
--- a/classes/sota_qemux86-64.bbclass
+++ b/classes/sota_qemux86-64.bbclass
@@ -4,7 +4,7 @@ PREFERRED_VERSION_linux-yocto_qemux86-64_sota = "4.4%"
 IMAGE_FSTYPES_remove = "wic"
 
 # U-Boot support for SOTA
-PREFERRED_PROVIDER_virtual/bootloader_sota = "u-boot"
+PREFERRED_PROVIDER_virtual/bootloader_sota = "u-boot-ota"
 UBOOT_MACHINE_sota = "qemu-x86_defconfig"
 OSTREE_BOOTLOADER ?= "u-boot"
 


### PR DESCRIPTION
Use u-boot-ota recipe for QEMU x86-64 bootloader.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>