### PR TITLE
Remove OSTREE_BRANCHNAME mention in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -66,7 +66,6 @@ Although we have used U-Boot so far, other boot loaders can be configured work w
 == SOTA-related variables in local.conf
 
 * `OSTREE_REPO` - path to your OSTree repository. Defaults to `$\{DEPLOY_DIR_IMAGE}/ostree_repo`
-* `OSTREE_BRANCHNAME` - the branch your rootfs will be committed to. Defaults to the same value as `MACHINE`.
 * `OSTREE_OSNAME` - OS deployment name on your target device. For more information about deployments and osnames see the https://ostree.readthedocs.io/en/latest/manual/deployment/[OSTree documentation]. Defaults to "poky".
 * `OSTREE_INITRAMFS_IMAGE` - initramfs/initrd image that is used as a proxy while booting into OSTree deployment. Do not change this setting unless you are sure that your initramfs can serve as such a proxy.
 * `SOTA_PACKED_CREDENTIALS` - when set, your ostree commit will be pushed to a remote repo as a bitbake step. This should be the path to a zipped credentials file in https://github.com/advancedtelematic/aktualizr/blob/master/docs/credentials.adoc[the format accepted by garage-push].


### PR DESCRIPTION
Not relevant to the user, as per PRO-4483