### PR TITLE
Bump aktualizr to get open source server CA fix.

### DIFF
--- a/recipes-sota/aktualizr/aktualizr-implicit-prov.bb
+++ b/recipes-sota/aktualizr/aktualizr-implicit-prov.bb
@@ -27,7 +27,7 @@ do_install() {
     install -d ${D}${libdir}/sota
     if [ -n "${SOTA_PACKED_CREDENTIALS}" ]; then
         aktualizr_implicit_writer -c ${SOTA_PACKED_CREDENTIALS} \
-            -i ${STAGING_DIR_NATIVE}${libdir}/sota/sota_implicit_prov.toml -o ${D}${libdir}/sota/sota.toml -p ${D} --no-root-ca
+            -i ${STAGING_DIR_NATIVE}${libdir}/sota/sota_implicit_prov.toml -o ${D}${libdir}/sota/sota.toml -p ${D}
     fi
 }
 

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -18,7 +18,7 @@ PR = "7"
 SRC_URI = " \
   git://github.com/advancedtelematic/aktualizr;branch=${BRANCH} \
   "
-SRCREV = "eb6c0b43c2b8b32f66f228c1c3f590b5c16ad448"
+SRCREV = "6bd88e1de1f0216c0b411868af3a596d9974cd0c"
 BRANCH ?= "master"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Also remove `--no-root-ca` for implicit prov. It's still there for the HSM case. If we really do need that flag for the implict recipe for Spekulatius, then we need to do some thinking.