### PR TITLE
Bugfix/pro 4632/morty pseudo bugs

### DIFF
--- a/recipes-support/sqlite/sqlite3_3.14.1.bbappend
+++ b/recipes-support/sqlite/sqlite3_3.14.1.bbappend
@@ -1,0 +1,1 @@
+CFLAGS_append = " -fPIC"

--- a/scripts/envsetup.sh
+++ b/scripts/envsetup.sh
@@ -24,15 +24,7 @@ fi
 METADIR="${SOURCEDIR}/../.."
 
 if [[ ! -f "${BUILDDIR}/conf/local.conf" ]]; then
-  if [ -z "$TEMPLATECONF" ] && [ -d ${METADIR}/meta-updater-${MACHINE}/conf ]; then
-    # Use the template configurations for the specified machine
-    TEMPLATECONF=${METADIR}/meta-updater-${MACHINE}/conf
-    source "$METADIR/poky/oe-init-build-env" "$BUILDDIR"
-    unset TEMPLATECONF
-  else
-    # Use the default configurations or TEMPLATECONF set by the user
-    source "$METADIR/poky/oe-init-build-env" "$BUILDDIR"
-  fi
+  source "$METADIR/poky/oe-init-build-env" "$BUILDDIR"
   echo "METADIR  := \"\${@os.path.abspath('${METADIR}')}\"" >> conf/bblayers.conf
   cat "${METADIR}/meta-updater/conf/include/bblayers/sota.inc" >> conf/bblayers.conf
   cat "${METADIR}/meta-updater/conf/include/bblayers/sota_${MACHINE}.inc" >> conf/bblayers.conf


### PR DESCRIPTION
Backport some pyro fixes to morty to fix issues around pseudo.

First, sqlite needs to be built with -fPIC on some systems to make linking it with pseudo-native work.

Second, in some installations, pseudo-native would fail because of a previously backported patch getting doubly applied. The problem was some cleverness in envsetup.sh that accidentally created duplicate layers.