### PR TITLE
sota_raspberrypi*.inc: Included meta-python

### DIFF
--- a/classes/sota_raspberrypi.bbclass
+++ b/classes/sota_raspberrypi.bbclass
@@ -3,6 +3,7 @@ PREFERRED_PROVIDER_virtual/bootloader_sota ?= "u-boot"
 UBOOT_MACHINE_raspberrypi2_sota ?= "rpi_2_defconfig"
 UBOOT_MACHINE_raspberrypi3_sota ?= "rpi_3_32b_defconfig"
 
+IMAGE_FSTYPES_remove_sota = "rpi-sdimg"
 OSTREE_BOOTLOADER ?= "u-boot"
 
 # OSTree puts its own boot.scr to bcm2835-bootfiles

--- a/conf/include/bblayers/sota_raspberrypi2.inc
+++ b/conf/include/bblayers/sota_raspberrypi2.inc
@@ -1,2 +1,3 @@
+BBLAYERS += " ${METADIR}/meta-openembedded/meta-python "
 
 BBLAYERS += " ${METADIR}/meta-updater-raspberrypi ${METADIR}/meta-raspberrypi " 

--- a/conf/include/bblayers/sota_raspberrypi3.inc
+++ b/conf/include/bblayers/sota_raspberrypi3.inc
@@ -1,2 +1,3 @@
+BBLAYERS += " ${METADIR}/meta-openembedded/meta-python "
 
 BBLAYERS += " ${METADIR}/meta-updater-raspberrypi ${METADIR}/meta-raspberrypi " 


### PR DESCRIPTION
Add Yocto/OE layer meta-python to bblayers as it
required for building recipe rpi-gpio for Yocto/OE
layer meta-raspberrypi.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>
  