### PR TITLE
sota_raspberrypi.bbclass: Enable U-Boot for Raspberry Pi

### DIFF
--- a/classes/sota_raspberrypi.bbclass
+++ b/classes/sota_raspberrypi.bbclass
@@ -1,3 +1,4 @@
+RPI_USE_U_BOOT_sota = "1"
 KERNEL_IMAGETYPE_sota = "uImage"
 PREFERRED_PROVIDER_virtual/bootloader_sota ?= "u-boot"
 UBOOT_MACHINE_raspberrypi2_sota ?= "rpi_2_defconfig"


### PR DESCRIPTION
Enable U-Boot for Raspberry Pi using the new setting
from Yocto/OE layer meta-raspberrypi RPI_USE_U_BOOT.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>