### PR TITLE
Add EVP_PKEY_meth_get* replacement functions to use with OpenSSL 1.0.…

### DIFF
--- a/recipes-support/libp11/files/0001-Workaround-for-a-buggy-version-of-openssl-1.0.2m.patch
+++ b/recipes-support/libp11/files/0001-Workaround-for-a-buggy-version-of-openssl-1.0.2m.patch
@@ -1,0 +1,42 @@
+From ccab5ce63dd5d3dbb4bd02998d21d34407e550f2 Mon Sep 17 00:00:00 2001
+From: Anton Gerasimov <anton.gerasimov@here.com>
+Date: Fri, 19 Jan 2018 12:44:27 +0100
+Subject: [PATCH] Workaround for a buggy version of openssl (1.0.2m)
+
+---
+ src/p11_pkey.c | 12 +++++++++---
+ 1 file changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/src/p11_pkey.c b/src/p11_pkey.c
+index 45d5ad3..75625e6 100644
+--- a/src/p11_pkey.c
++++ b/src/p11_pkey.c
+@@ -139,8 +139,14 @@ static void EVP_PKEY_meth_copy(EVP_PKEY_METHOD *dst, const EVP_PKEY_METHOD *src)
+ 
+ #endif
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x100020d0L || defined(LIBRESSL_VERSION_NUMBER)
+-static void EVP_PKEY_meth_get_sign(EVP_PKEY_METHOD *pmeth,
++#if OPENSSL_VERSION_NUMBER <= 0x100020e0L || defined(LIBRESSL_VERSION_NUMBER)
++
++#  if (OPENSSL_VERSION_NUMBER & 0xFFFFFFF0) == 0x100020d0L
++#    undef EVP_PKEY_meth_get_sign
++#    undef EVP_PKEY_meth_get_decrypt
++#  endif
++
++void EVP_PKEY_meth_get_sign(EVP_PKEY_METHOD *pmeth,
+ 		int (**psign_init) (EVP_PKEY_CTX *ctx),
+ 		int (**psign) (EVP_PKEY_CTX *ctx,
+ 			unsigned char *sig, size_t *siglen,
+@@ -152,7 +158,7 @@ static void EVP_PKEY_meth_get_sign(EVP_PKEY_METHOD *pmeth,
+ 		*psign = pmeth->sign;
+ }
+ 
+-static void EVP_PKEY_meth_get_decrypt(EVP_PKEY_METHOD *pmeth,
++void EVP_PKEY_meth_get_decrypt(EVP_PKEY_METHOD *pmeth,
+ 		int (**pdecrypt_init) (EVP_PKEY_CTX *ctx),
+ 		int (**pdecrypt) (EVP_PKEY_CTX *ctx,
+ 			unsigned char *out,
+-- 
+2.15.1
+

--- a/recipes-support/libp11/libp11_0.4.7.bb
+++ b/recipes-support/libp11/libp11_0.4.7.bb
@@ -8,7 +8,8 @@ LICENSE = "LGPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=fad9b3332be894bab9bc501572864b29"
 DEPENDS = "libtool openssl"
 
-SRC_URI = "git://github.com/OpenSC/libp11.git"
+SRC_URI = "git://github.com/OpenSC/libp11.git \
+           file://0001-Workaround-for-a-buggy-version-of-openssl-1.0.2m.patch"
 SRCREV = "da725ab727342083478150a203a3c80c4551feb4"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
…2m as well

I couldn't find the reason why these functions are not present in libopenssl.so,
but apparently it doesn't affect 1.0.2k