### PR TITLE
Deploy initial primary version information

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -12,6 +12,8 @@ IMAGE_DEPENDS_ostree = "ostree-native:do_populate_sysroot \
 export OSTREE_REPO
 export OSTREE_BRANCHNAME
 
+export GARAGE_TARGET_NAME
+
 RAMDISK_EXT ?= ".ext4.gz"
 RAMDISK_EXT_arm ?= ".ext4.gz.u-boot"
 
@@ -205,7 +207,7 @@ IMAGE_CMD_garagesign () {
         push_success=0
         for push_retries in $( seq 3 ); do
             garage-sign targets pull --repo tufrepo --home-dir ${GARAGE_SIGN_REPO}
-            garage-sign targets add --repo tufrepo --home-dir ${GARAGE_SIGN_REPO} --name ${OSTREE_BRANCHNAME} --format OSTREE --version ${ostree_target_hash} --length 0 --url "https://example.com/" --sha256 ${ostree_target_hash} --hardwareids ${MACHINE}
+            garage-sign targets add --repo tufrepo --home-dir ${GARAGE_SIGN_REPO} --name ${GARAGE_TARGET_NAME} --format OSTREE --version ${ostree_target_hash} --length 0 --url "https://example.com/" --sha256 ${ostree_target_hash} --hardwareids ${MACHINE}
             garage-sign targets sign --repo tufrepo --home-dir ${GARAGE_SIGN_REPO} --key-name=targets
             errcode=0
             garage-sign targets push --repo tufrepo --home-dir ${GARAGE_SIGN_REPO} || errcode=$?

--- a/classes/image_types_ota.bbclass
+++ b/classes/image_types_ota.bbclass
@@ -53,6 +53,8 @@ export OSTREE_BRANCHNAME
 export OSTREE_REPO
 export OSTREE_BOOTLOADER
 
+export GARAGE_TARGET_NAME
+
 IMAGE_CMD_otaimg () {
 	if ${@bb.utils.contains('IMAGE_FSTYPES', 'otaimg', 'true', 'false', d)}; then
 		if [ -z "$OSTREE_REPO" ]; then
@@ -106,6 +108,9 @@ IMAGE_CMD_otaimg () {
 		mv ${HOME_TMP}/usr/homedirs/home ${PHYS_SYSROOT}/ || true
 		# Ensure that /var/local exists (AGL symlinks /usr/local to /var/local)
 		install -d ${PHYS_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/local
+		# Set package version for the first deployment
+		echo "{\"${ostree_target_hash}\":\"${GARAGE_TARGET_NAME}-${ostree_target_hash}\"}" > ${PHYS_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/sota/installed_versions
+
 		rm -rf ${HOME_TMP}
 
 		# Calculate image type


### PR DESCRIPTION
A bit hacky method, but OSTree refhash is only known to image_types_ostree and image_types_ota bbclasses, so I couldn't figure out a better one.
I couldn't test it on staging yet, where it has most sense, but on prod it seems to send a reasonable manifest.
Should work with SQLite as well, because of how FS->SQL migration works (and yes, it's also a hack).
Making a PR to pyro, we'll have to merge a couple of things again when we make the final transition to rocko.