### PR TITLE
grub-efi: remove bbappend as change is now provided by oe-core

### DIFF
--- a/recipes-bsp/grub/grub-efi_%.bbappend
+++ b/recipes-bsp/grub/grub-efi_%.bbappend
@@ -1,2 +1,0 @@
-
-GRUB_BUILDIN_append_sota = " configfile"


### PR DESCRIPTION
grub-efi from oe-core now includes configfile in the default buildin
modules list.

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>