### PR TITLE
ostree: fix systemd service files permission

### DIFF
--- a/recipes-sota/ostree/ostree_git.bb
+++ b/recipes-sota/ostree/ostree_git.bb
@@ -63,8 +63,8 @@ export SYSTEMD_REQUIRED
 
 do_install_append() {
  if [ -n ${SYSTEMD_REQUIRED} ]; then
-  install -p -D ${S}/src/boot/ostree-prepare-root.service ${D}${systemd_unitdir}/system/ostree-prepare-root.service
-  install -p -D ${S}/src/boot/ostree-remount.service ${D}${systemd_unitdir}/system/ostree-remount.service
+  install -m 0644 -D ${S}/src/boot/ostree-prepare-root.service ${D}${systemd_unitdir}/system/ostree-prepare-root.service
+  install -m 0644 -D ${S}/src/boot/ostree-remount.service ${D}${systemd_unitdir}/system/ostree-remount.service
  fi
 }
 


### PR DESCRIPTION
Fix the following boot warning:
systemd[1]: Configuration file /usr/lib/systemd/system/ostree-remount.service
is marked executable. Please remove executable permission bits. Proceeding
anyway.

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>