### PR TITLE
Test/pro 4481/hsm rocko

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,10 +17,10 @@ If you don't already have a Yocto project that you want to add OTA to, you can u
 If you already have a Yocto-based project and you want to add atomic filesystem updates to it, you just need to do three things:
 
 1.  Clone the `meta-updater` layer and add it to your https://www.yoctoproject.org/docs/2.1/ref-manual/ref-manual.html#structure-build-conf-bblayers.conf[bblayers.conf].
-2.  Clone BSP integration layer (meta-updater-$\{PLATFORM}, e.g. https://github.com/advancedtelematic/meta-updater-raspberrypi[meta-updater-raspberrypi]) and add it to your conf/bblayers.conf. If your board isn't supported yet, you could write a BSP integration for it yourself. See the <<Adding support for your board>> section for the details.
-3.  Set up your https://www.yoctoproject.org/docs/2.1/ref-manual/ref-manual.html#var-DISTRO[distro]. If you are using "poky", the default distro in Yocto, you can change it in your conf/local.conf to "poky-sota". Alternatively, if you are using your own or third party distro configuration, you can add 'INHERIT += " sota"' to it, thus combining capabilities of your distro with meta-updater features.
+2.  Clone BSP integration layer (`meta-updater-$\{PLATFORM}`, e.g. https://github.com/advancedtelematic/meta-updater-raspberrypi[meta-updater-raspberrypi]) and add it to your `conf/bblayers.conf`. If your board isn't supported yet, you could write a BSP integration for it yourself. See the <<Adding support for your board>> section for the details.
+3.  Set up your https://www.yoctoproject.org/docs/2.1/ref-manual/ref-manual.html#var-DISTRO[distro]. If you are using "poky", the default distro in Yocto, you can change it in your `conf/local.conf` to "poky-sota". Alternatively, if you are using your own or third party distro configuration, you can add `INHERIT += " sota"` to it, thus combining capabilities of your distro with meta-updater features.
 
-You can then build your image as usual, with bitbake. After building the root file system, bitbake will then create an https://ostree.readthedocs.io/en/latest/manual/adapting-existing/[OSTree-enabled version] of it, commit it to your local OSTree repo and (optionally) push it to a remote server. Additionally, a live disk image will be created (normally named $\{IMAGE_NAME}.-sdimg-ota e.g. core-image-raspberrypi3.rpi-sdimg-ota). You can control this behaviour through <<variables in your local.conf,OSTree-related variables in your local.conf>>.
+You can then build your image as usual, with bitbake. After building the root file system, bitbake will then create an https://ostree.readthedocs.io/en/latest/manual/adapting-existing/[OSTree-enabled version] of it, commit it to your local OSTree repo and (optionally) push it to a remote server. Additionally, a live disk image will be created (normally named `$\{IMAGE_NAME}.-sdimg-ota` e.g. `core-image-raspberrypi3.rpi-sdimg-ota`). You can control this behaviour through <<variables in your local.conf,OSTree-related variables in your local.conf>>.
 
 === Build in AGL
 
@@ -30,19 +30,19 @@ With AGL you can just add agl-sota feature while configuring your build environm
 source meta-agl/scripts/aglsetup.sh -m porter agl-demo agl-appfw-smack agl-devel agl-sota
 ....
 
-you can then run
+You can then run:
 
 ....
 bitbake agl-demo-platform
 ....
 
-and get as a result an "ostree_repo" folder in your images directory (tmp/deploy/images/$\{MACHINE}/ostree_repo). It will contain
+and get as a result an `ostree_repo` folder in your images directory (`tmp/deploy/images/$\{MACHINE}/ostree_repo`). It will contain:
 
 * your OSTree repository, with the rootfs committed as an OSTree deployment,
-* an 'otaimg' bootstrap image, which is an OSTree physical sysroot as a burnable filesystem image, and optionally
-* some machine-dependent live images (e.g. '_.rpi-sdimg-ota' for Raspberry Pi or '_.porter-sdimg-ota' Renesas Porter board).
+* an `otaimg` bootstrap image, which is an OSTree physical sysroot as a burnable filesystem image, and optionally
+* some machine-dependent live images (e.g. `.rpi-sdimg-ota` for Raspberry Pi or `.porter-sdimg-ota` Renesas Porter board).
 
-Although aglsetup.sh hooks provide reasonable defaults for SOTA-related variables, you may want to tune some of them.
+Although `aglsetup.sh` hooks provide reasonable defaults for SOTA-related variables, you may want to tune some of them.
 
 === Build problems
 
@@ -73,7 +73,7 @@ You may take a look into https://github.com/advancedtelematic/meta-updater-minno
 
 Although we have used U-Boot so far, other boot loaders can be configured work with OSTree as well.
 
-== SOTA-related variables in local.conf
+== SOTA-related variables in `local.conf`
 
 * `OSTREE_REPO` - path to your OSTree repository. Defaults to `$\{DEPLOY_DIR_IMAGE}/ostree_repo`
 * `OSTREE_OSNAME` - OS deployment name on your target device. For more information about deployments and osnames see the https://ostree.readthedocs.io/en/latest/manual/deployment/[OSTree documentation]. Defaults to "poky".
@@ -135,18 +135,32 @@ garage-push --repo=/path/to/ostree-repo --ref=mybranch --credentials=/path/to/cr
 
 You can set `SOTA_PACKED_CREDENTIALS` in your `local.conf` to automatically synchronize your build results with a remote server. Credentials are stored in an archive as described in the https://github.com/advancedtelematic/aktualizr/blob/master/docs/credentials.adoc[aktualizr documentation].
 
-=== QA
+== QA with `oe-selftest`
 
 This layer relies on the test framework oe-selftest for quality assurance. Follow the steps below to run the tests:
 
-* Append the line below to conf/local.conf
-
+1. Append the line below to `conf/local.conf` to disable the warning about supported operating systems:
++
 ```
-SANITY_TESTED_DISTROS=""
+SANITY_TESTED_DISTROS = ""
 ```
 
-* Run oe-selftest:
+2. If your image does not already include an ssh daemon such as dropbear or openssh, add this line to `conf/local.conf` as well:
++
+```
+IMAGE_INSTALL_append = " dropbear "
+```
 
+3. To be able to build an image for the grub tests, you will need to install https://github.com/tianocore/tianocore.github.io/wiki/OVMF[TianoCore's ovmf] package on your host system. On Debian-like systems, you can do so with this command:
++
+```
+sudo apt install ovmf
+```
+
+4. Run oe-selftest:
++
 ```
 oe-selftest --run-tests updater
 ```
+
+For more information about oe-selftest, including details about how to run individual test modules or classes, please refer to the https://wiki.yoctoproject.org/wiki/Oe-selftest[Yocto Project wiki].

--- a/lib/oeqa/selftest/cases/updater.py
+++ b/lib/oeqa/selftest/cases/updater.py
@@ -1,6 +1,7 @@
 # pylint: disable=C0111,C0325
 import os
 import logging
+import re
 import subprocess
 import unittest
 from time import sleep
@@ -20,32 +21,13 @@ class SotaToolsTests(OESelftestTestCase):
         bitbake('aktualizr-native')
 
     def test_push_help(self):
-        bb_vars = get_bb_vars(['SYSROOT_DESTDIR', 'bindir'], 'aktualizr-native')
-        p = bb_vars['SYSROOT_DESTDIR'] + bb_vars['bindir'] + "/" + "garage-push"
-        self.assertTrue(os.path.isfile(p), msg = "No garage-push found (%s)" % p)
-        result = runCmd('%s --help' % p, ignore_status=True)
-        self.assertEqual(result.status, 0, "Status not equal to 0. output: %s" % result.output)
+        akt_native_run(self, 'garage-push --help')
 
     def test_deploy_help(self):
-        bb_vars = get_bb_vars(['SYSROOT_DESTDIR', 'bindir'], 'aktualizr-native')
-        p = bb_vars['SYSROOT_DESTDIR'] + bb_vars['bindir'] + "/" + "garage-deploy"
-        self.assertTrue(os.path.isfile(p), msg = "No garage-deploy found (%s)" % p)
-        result = runCmd('%s --help' % p, ignore_status=True)
-        self.assertEqual(result.status, 0, "Status not equal to 0. output: %s" % result.output)
+        akt_native_run(self, 'garage-deploy --help')
 
     def test_garagesign_help(self):
-        bb_vars = get_bb_vars(['SYSROOT_DESTDIR', 'bindir'], 'aktualizr-native')
-        p = bb_vars['SYSROOT_DESTDIR'] + bb_vars['bindir'] + "/" + "garage-sign"
-        self.assertTrue(os.path.isfile(p), msg = "No garage-sign found (%s)" % p)
-        result = runCmd('%s --help' % p, ignore_status=True)
-        self.assertEqual(result.status, 0, "Status not equal to 0. output: %s" % result.output)
-
-
-class HsmTests(OESelftestTestCase):
-
-    def test_hsm(self):
-        self.write_config('SOTA_CLIENT_FEATURES="hsm"')
-        bitbake('core-image-minimal')
+        akt_native_run(self, 'garage-sign --help')
 
 
 class GeneralTests(OESelftestTestCase):
@@ -59,6 +41,9 @@ class GeneralTests(OESelftestTestCase):
         self.assertNotEqual(result, -1, 'Feature "systemd" not set at DISTRO_FEATURES')
 
     def test_credentials(self):
+        logger = logging.getLogger("selftest")
+        logger.info('Running bitbake to build core-image-minimal')
+        self.append_config('SOTA_CLIENT_PROV = "aktualizr-auto-prov"')
         bitbake('core-image-minimal')
         credentials = get_bb_var('SOTA_PACKED_CREDENTIALS')
         # skip the test if the variable SOTA_PACKED_CREDENTIALS is not set
@@ -75,7 +60,8 @@ class GeneralTests(OESelftestTestCase):
 
     def test_java(self):
         result = runCmd('which java', ignore_status=True)
-        self.assertEqual(result.status, 0, "Java not found.")
+        self.assertEqual(result.status, 0,
+                         "Java not found. Do you have a JDK installed on your host machine?")
 
     def test_add_package(self):
         print('')
@@ -85,7 +71,7 @@ class GeneralTests(OESelftestTestCase):
         logger = logging.getLogger("selftest")
 
         logger.info('Running bitbake with man in the image package list')
-        self.write_config('IMAGE_INSTALL_append = " man "')
+        self.append_config('IMAGE_INSTALL_append = " man "')
         bitbake('-c cleanall man')
         bitbake('core-image-minimal')
         result = runCmd('oe-pkgdata-util find-path /usr/bin/man')
@@ -95,7 +81,7 @@ class GeneralTests(OESelftestTestCase):
         logger.info('First image %s has size %i' % (path1, size1))
 
         logger.info('Running bitbake without man in the image package list')
-        self.write_config('IMAGE_INSTALL_remove = " man "')
+        self.append_config('IMAGE_INSTALL_remove = " man "')
         bitbake('-c cleanall man')
         bitbake('core-image-minimal')
         result = runCmd('oe-pkgdata-util find-path /usr/bin/man', ignore_status=True)
@@ -108,6 +94,46 @@ class GeneralTests(OESelftestTestCase):
         self.assertNotEqual(size1, size2, "Image sizes are identical; image was not rebuilt.")
 
 
+class AktualizrToolsTests(OESelftestTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(AktualizrToolsTests, cls).setUpClass()
+        logger = logging.getLogger("selftest")
+        logger.info('Running bitbake to build aktualizr-native tools')
+        bitbake('aktualizr-native')
+
+    def test_implicit_writer_help(self):
+        akt_native_run(self, 'aktualizr_implicit_writer --help')
+
+    def test_cert_provider_help(self):
+        akt_native_run(self, 'aktualizr_cert_provider --help')
+
+    def test_cert_provider_local_output(self):
+        logger = logging.getLogger("selftest")
+        logger.info('Running bitbake to build aktualizr-implicit-prov')
+        bitbake('aktualizr-implicit-prov')
+        bb_vars = get_bb_vars(['SOTA_PACKED_CREDENTIALS', 'T'], 'aktualizr-native')
+        creds = bb_vars['SOTA_PACKED_CREDENTIALS']
+        temp_dir = bb_vars['T']
+        bb_vars_prov = get_bb_vars(['STAGING_DIR_NATIVE', 'libdir'], 'aktualizr-implicit-prov')
+        config = bb_vars_prov['STAGING_DIR_NATIVE'] + bb_vars_prov['libdir'] + '/sota/sota_implicit_prov.toml'
+
+        akt_native_run(self, 'aktualizr_cert_provider -c {creds} -r -l {temp} -g {config}'
+                       .format(creds=creds, temp=temp_dir, config=config))
+
+        # Might be nice if these names weren't hardcoded.
+        cert_path = temp_dir + '/client.pem'
+        self.assertTrue(os.path.isfile(cert_path), "Client certificate not found at %s." % cert_path)
+        self.assertTrue(os.path.getsize(cert_path) > 0, "Client certificate at %s is empty." % cert_path)
+        pkey_path = temp_dir + '/pkey.pem'
+        self.assertTrue(os.path.isfile(pkey_path), "Private key not found at %s." % pkey_path)
+        self.assertTrue(os.path.getsize(pkey_path) > 0, "Private key at %s is empty." % pkey_path)
+        ca_path = temp_dir + '/root.crt'
+        self.assertTrue(os.path.isfile(ca_path), "Client certificate not found at %s." % ca_path)
+        self.assertTrue(os.path.getsize(ca_path) > 0, "Client certificate at %s is empty." % ca_path)
+
+
 class QemuTests(OESelftestTestCase):
 
     @classmethod
@@ -118,14 +144,16 @@ class QemuTests(OESelftestTestCase):
     @classmethod
     def tearDownClass(cls):
         qemu_terminate(cls.s)
+        super(QemuTests, cls).tearDownClass()
 
-    def run_command(self, command):
+    def qemu_command(self, command):
         return qemu_send_command(self.qemu.ssh_port, command)
 
-    def test_hostname(self):
-        print('')
+    def test_qemu(self):
         print('Checking machine name (hostname) of device:')
-        stdout, stderr, retcode = self.run_command('hostname')
+        stdout, stderr, retcode = self.qemu_command('hostname')
+        self.assertEqual(retcode, 0, "Unable to check hostname. " +
+                         "Is an ssh daemon (such as dropbear or openssh) installed on the device?")
         machine = get_bb_var('MACHINE', 'core-image-minimal')
         self.assertEqual(stderr, b'', 'Error: ' + stderr.decode())
         # Strip off line ending.
@@ -133,30 +161,15 @@ class QemuTests(OESelftestTestCase):
         self.assertEqual(value_str, machine,
                          'MACHINE does not match hostname: ' + machine + ', ' + value_str)
         print(value_str)
-
-    def test_var_sota(self):
-        print('')
-        print('Checking contents of /var/sota:')
-        stdout, stderr, retcode = self.run_command('ls /var/sota')
-        self.assertEqual(stderr, b'', 'Error: ' + stderr.decode())
-        self.assertEqual(retcode, 0)
-        print(stdout.decode())
-
-    def test_aktualizr_info(self):
         print('Checking output of aktualizr-info:')
         ran_ok = False
         for delay in [0, 1, 2, 5, 10, 15]:
             sleep(delay)
-            try:
-                stdout, stderr, retcode = self.run_command('aktualizr-info')
-                if retcode == 0 and stderr == b'':
-                    ran_ok = True
-                    break
-            except IOError as e:
-                print(e)
-        if not ran_ok:
-            print(stdout.decode())
-            print(stderr.decode())
+            stdout, stderr, retcode = self.qemu_command('aktualizr-info')
+            if retcode == 0 and stderr == b'':
+                ran_ok = True
+                break
+        self.assertTrue(ran_ok, 'aktualizr-info failed: ' + stderr.decode() + stdout.decode())
 
 
 class GrubTests(OESelftestTestCase):
@@ -178,19 +191,220 @@ class GrubTests(OESelftestTestCase):
         runCmd('bitbake-layers remove-layer "%s"' % self.meta_intel, ignore_status=True)
         runCmd('bitbake-layers remove-layer "%s"' % self.meta_minnow, ignore_status=True)
 
+    def qemu_command(self, command):
+        return qemu_send_command(self.qemu.ssh_port, command)
+
     def test_grub(self):
         print('')
         print('Checking machine name (hostname) of device:')
-        value, err, retcode = qemu_send_command(self.qemu.ssh_port, 'hostname')
+        stdout, stderr, retcode = self.qemu_command('hostname')
+        self.assertEqual(retcode, 0, "Unable to check hostname. " +
+                         "Is an ssh daemon (such as dropbear or openssh) installed on the device?")
         machine = get_bb_var('MACHINE', 'core-image-minimal')
-        self.assertEqual(err, b'', 'Error: ' + err.decode())
-        self.assertEqual(retcode, 0)
+        self.assertEqual(stderr, b'', 'Error: ' + stderr.decode())
         # Strip off line ending.
-        value_str = value.decode()[:-1]
+        value = stdout.decode()[:-1]
+        self.assertEqual(value, machine,
+                         'MACHINE does not match hostname: ' + machine + ', ' + value +
+                         '\nIs TianoCore ovmf installed on your host machine?')
+        print(value)
+        print('Checking output of aktualizr-info:')
+        ran_ok = False
+        for delay in [0, 1, 2, 5, 10, 15]:
+            sleep(delay)
+            stdout, stderr, retcode = self.qemu_command('aktualizr-info')
+            if retcode == 0 and stderr == b'':
+                ran_ok = True
+                break
+        self.assertTrue(ran_ok, 'aktualizr-info failed: ' + stderr.decode() + stdout.decode())
+
+
+class ImplProvTests(OESelftestTestCase):
+
+    def setUpLocal(self):
+        self.append_config('SOTA_CLIENT_PROV = " aktualizr-implicit-prov "')
+        # note: this will build aktualizr-native as a side-effect
+        self.qemu, self.s = qemu_launch(machine='qemux86-64')
+
+    def tearDownLocal(self):
+        qemu_terminate(self.s)
+
+    def qemu_command(self, command):
+        return qemu_send_command(self.qemu.ssh_port, command)
+
+    def test_provisioning(self):
+        print('Checking machine name (hostname) of device:')
+        stdout, stderr, retcode = self.qemu_command('hostname')
+        self.assertEqual(retcode, 0, "Unable to check hostname. " +
+                         "Is an ssh daemon (such as dropbear or openssh) installed on the device?")
+        machine = get_bb_var('MACHINE', 'core-image-minimal')
+        self.assertEqual(stderr, b'', 'Error: ' + stderr.decode())
+        # Strip off line ending.
+        value_str = stdout.decode()[:-1]
+        self.assertEqual(value_str, machine,
+                         'MACHINE does not match hostname: ' + machine + ', ' + value_str)
+        print(value_str)
+        print('Checking output of aktualizr-info:')
+        ran_ok = False
+        for delay in [0, 1, 2, 5, 10, 15]:
+            stdout, stderr, retcode = self.qemu_command('aktualizr-info')
+            if retcode == 0 and stderr == b'':
+                ran_ok = True
+                break
+        self.assertTrue(ran_ok, 'aktualizr-info failed: ' + stderr.decode() + stdout.decode())
+        # Verify that device has NOT yet provisioned.
+        self.assertIn(b'Couldn\'t load device ID', stdout,
+                      'Device already provisioned!? ' + stderr.decode() + stdout.decode())
+        self.assertIn(b'Couldn\'t load ECU serials', stdout,
+                      'Device already provisioned!? ' + stderr.decode() + stdout.decode())
+        self.assertIn(b'Provisioned on server: no', stdout,
+                      'Device already provisioned!? ' + stderr.decode() + stdout.decode())
+        self.assertIn(b'Fetched metadata: no', stdout,
+                      'Device already provisioned!? ' + stderr.decode() + stdout.decode())
+
+        # Run cert_provider.
+        bb_vars = get_bb_vars(['SOTA_PACKED_CREDENTIALS'], 'aktualizr-native')
+        creds = bb_vars['SOTA_PACKED_CREDENTIALS']
+        bb_vars_prov = get_bb_vars(['STAGING_DIR_NATIVE', 'libdir'], 'aktualizr-implicit-prov')
+        config = bb_vars_prov['STAGING_DIR_NATIVE'] + bb_vars_prov['libdir'] + '/sota/sota_implicit_prov.toml'
+
+        akt_native_run(self, 'aktualizr_cert_provider -c {creds} -t root@localhost -p {port} -s -g {config}'
+                       .format(creds=creds, port=self.qemu.ssh_port, config=config))
+
+        # Verify that device HAS provisioned.
+        ran_ok = False
+        for delay in [5, 5, 5, 5, 10]:
+            sleep(delay)
+            stdout, stderr, retcode = self.qemu_command('aktualizr-info')
+            if retcode == 0 and stderr == b'' and stdout.decode().find('Fetched metadata: yes') >= 0:
+                ran_ok = True
+                break
+        self.assertIn(b'Device ID: ', stdout, 'Provisioning failed: ' + stderr.decode() + stdout.decode())
+        self.assertIn(b'Primary ecu hardware ID: qemux86-64', stdout,
+                      'Provisioning failed: ' + stderr.decode() + stdout.decode())
+        self.assertIn(b'Fetched metadata: yes', stdout, 'Provisioning failed: ' + stderr.decode() + stdout.decode())
+        p = re.compile(r'Device ID: ([a-z0-9-]*)\n')
+        m = p.search(stdout.decode())
+        self.assertTrue(m, 'Device ID could not be read: ' + stderr.decode() + stdout.decode())
+        self.assertGreater(m.lastindex, 0, 'Device ID could not be read: ' + stderr.decode() + stdout.decode())
+        logger = logging.getLogger("selftest")
+        logger.info('Device successfully provisioned with ID: ' + m.group(1))
+
+
+class HsmTests(OESelftestTestCase):
+
+    def setUpLocal(self):
+        self.append_config('SOTA_CLIENT_PROV = "aktualizr-hsm-prov"')
+        self.append_config('SOTA_CLIENT_FEATURES = "hsm"')
+        # note: this will build aktualizr-native as a side-effect
+        self.qemu, self.s = qemu_launch(machine='qemux86-64')
+
+    def tearDownLocal(self):
+        qemu_terminate(self.s)
+
+    def qemu_command(self, command):
+        return qemu_send_command(self.qemu.ssh_port, command)
+
+    def test_provisioning(self):
+        print('Checking machine name (hostname) of device:')
+        stdout, stderr, retcode = self.qemu_command('hostname')
+        self.assertEqual(retcode, 0, "Unable to check hostname. " +
+                         "Is an ssh daemon (such as dropbear or openssh) installed on the device?")
+        machine = get_bb_var('MACHINE', 'core-image-minimal')
+        self.assertEqual(stderr, b'', 'Error: ' + stderr.decode())
+        # Strip off line ending.
+        value_str = stdout.decode()[:-1]
         self.assertEqual(value_str, machine,
                          'MACHINE does not match hostname: ' + machine + ', ' + value_str +
                          '\nIs tianocore ovmf installed?')
         print(value_str)
+        print('Checking output of aktualizr-info:')
+        ran_ok = False
+        for delay in [0, 1, 2, 5, 10, 15]:
+            stdout, stderr, retcode = self.qemu_command('aktualizr-info')
+            if retcode == 0 and stderr == b'':
+                ran_ok = True
+                break
+        self.assertTrue(ran_ok, 'aktualizr-info failed: ' + stderr.decode() + stdout.decode())
+        # Verify that device has NOT yet provisioned.
+        self.assertIn(b'Couldn\'t load device ID', stdout,
+                      'Device already provisioned!? ' + stderr.decode() + stdout.decode())
+        self.assertIn(b'Couldn\'t load ECU serials', stdout,
+                      'Device already provisioned!? ' + stderr.decode() + stdout.decode())
+        self.assertIn(b'Provisioned on server: no', stdout,
+                      'Device already provisioned!? ' + stderr.decode() + stdout.decode())
+        self.assertIn(b'Fetched metadata: no', stdout,
+                      'Device already provisioned!? ' + stderr.decode() + stdout.decode())
+
+        # Verify that HSM is not yet initialized.
+        pkcs11_command = 'pkcs11-tool --module=/usr/lib/softhsm/libsofthsm2.so -O'
+        stdout, stderr, retcode = self.qemu_command(pkcs11_command)
+        self.assertNotEqual(retcode, 0, 'pkcs11-tool succeeded before initialization: ' +
+                            stdout.decode() + stderr.decode())
+        softhsm2_command = 'softhsm2-util --show-slots'
+        stdout, stderr, retcode = self.qemu_command(softhsm2_command)
+        self.assertNotEqual(retcode, 0, 'softhsm2-tool succeeded before initialization: ' +
+                        stdout.decode() + stderr.decode())
+
+        # Run cert_provider.
+        bb_vars = get_bb_vars(['SOTA_PACKED_CREDENTIALS'], 'aktualizr-native')
+        creds = bb_vars['SOTA_PACKED_CREDENTIALS']
+        bb_vars_prov = get_bb_vars(['STAGING_DIR_NATIVE', 'libdir'], 'aktualizr-hsm-prov')
+        config = bb_vars_prov['STAGING_DIR_NATIVE'] + bb_vars_prov['libdir'] + '/sota/sota_hsm_prov.toml'
+
+        akt_native_run(self, 'aktualizr_cert_provider -c {creds} -t root@localhost -p {port} -r -s -g {config}'
+                       .format(creds=creds, port=self.qemu.ssh_port, config=config))
+
+        # Verify that HSM is able to initialize.
+        ran_ok = False
+        for delay in [5, 5, 5, 5, 10]:
+            sleep(delay)
+            p11_out, p11_err, p11_ret = self.qemu_command(pkcs11_command)
+            hsm_out, hsm_err, hsm_ret = self.qemu_command(softhsm2_command)
+            if p11_ret == 0 and hsm_ret == 0 and hsm_err == b'':
+                ran_ok = True
+                break
+        self.assertTrue(ran_ok, 'pkcs11-tool or softhsm2-tool failed: ' + p11_err.decode() +
+                        p11_out.decode() + hsm_err.decode() + hsm_out.decode())
+        self.assertIn(b'present token', p11_err, 'pkcs11-tool failed: ' + p11_err.decode() + p11_out.decode())
+        self.assertIn(b'X.509 cert', p11_out, 'pkcs11-tool failed: ' + p11_err.decode() + p11_out.decode())
+        self.assertIn(b'Initialized:      yes', hsm_out, 'softhsm2-tool failed: ' +
+                      hsm_err.decode() + hsm_out.decode())
+        self.assertIn(b'User PIN init.:   yes', hsm_out, 'softhsm2-tool failed: ' +
+                      hsm_err.decode() + hsm_out.decode())
+
+        # Check that pkcs11 output matches sofhsm output.
+        p11_p = re.compile(r'Using slot [0-9] with a present token \((0x[0-9a-f]*)\)\s')
+        p11_m = p11_p.search(p11_err.decode())
+        self.assertTrue(p11_m, 'Slot number not found with pkcs11-tool: ' + p11_err.decode() + p11_out.decode())
+        self.assertGreater(p11_m.lastindex, 0, 'Slot number not found with pkcs11-tool: ' +
+                           p11_err.decode() + p11_out.decode())
+        hsm_p = re.compile(r'Description:\s*SoftHSM slot ID (0x[0-9a-f]*)\s')
+        hsm_m = hsm_p.search(hsm_out.decode())
+        self.assertTrue(hsm_m, 'Slot number not found with softhsm2-tool: ' + hsm_err.decode() + hsm_out.decode())
+        self.assertGreater(hsm_m.lastindex, 0, 'Slot number not found with softhsm2-tool: ' +
+                           hsm_err.decode() + hsm_out.decode())
+        self.assertEqual(p11_m.group(1), hsm_m.group(1), 'Slot number does not match: ' +
+                         p11_err.decode() + p11_out.decode() + hsm_err.decode() + hsm_out.decode())
+
+        # Verify that device HAS provisioned.
+        ran_ok = False
+        for delay in [5, 5, 5, 5, 10]:
+            sleep(delay)
+            stdout, stderr, retcode = self.qemu_command('aktualizr-info')
+            if retcode == 0 and stderr == b'' and stdout.decode().find('Fetched metadata: yes') >= 0:
+                ran_ok = True
+                break
+        self.assertIn(b'Device ID: ', stdout, 'Provisioning failed: ' + stderr.decode() + stdout.decode())
+        self.assertIn(b'Primary ecu hardware ID: qemux86-64', stdout,
+                      'Provisioning failed: ' + stderr.decode() + stdout.decode())
+        self.assertIn(b'Fetched metadata: yes', stdout, 'Provisioning failed: ' + stderr.decode() + stdout.decode())
+        p = re.compile(r'Device ID: ([a-z0-9-]*)\n')
+        m = p.search(stdout.decode())
+        self.assertTrue(m, 'Device ID could not be read: ' + stderr.decode() + stdout.decode())
+        self.assertGreater(m.lastindex, 0, 'Device ID could not be read: ' + stderr.decode() + stdout.decode())
+        logger = logging.getLogger("selftest")
+        logger.info('Device successfully provisioned with ID: ' + m.group(1))
 
 
 def qemu_launch(efi=False, machine=None):
@@ -220,11 +434,13 @@ def qemu_launch(efi=False, machine=None):
     sleep(10)
     return qemu, s
 
+
 def qemu_terminate(s):
     try:
         s.terminate()
     except KeyboardInterrupt:
         pass
+
 
 def qemu_send_command(port, command):
     command = ['ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@localhost -p ' +
@@ -232,5 +448,28 @@ def qemu_send_command(port, command):
     s2 = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = s2.communicate()
     return stdout, stderr, s2.returncode
+
+
+def akt_native_run(testInst, cmd, **kwargs):
+    # run a command supplied by aktualizr-native and checks that:
+    # - the executable exists
+    # - the command runs without error
+    # NOTE: the base test class must have built aktualizr-native (in
+    # setUpClass, for example)
+    bb_vars = get_bb_vars(['SYSROOT_DESTDIR', 'base_prefix', 'libdir', 'bindir'],
+                          'aktualizr-native')
+    sysroot = bb_vars['SYSROOT_DESTDIR'] + bb_vars['base_prefix']
+    sysrootbin = bb_vars['SYSROOT_DESTDIR'] + bb_vars['bindir']
+    libdir = bb_vars['libdir']
+
+    program, *_ = cmd.split(' ')
+    p = '{}/{}'.format(sysrootbin, program)
+    testInst.assertTrue(os.path.isfile(p), msg="No {} found ({})".format(program, p))
+    env = dict(os.environ)
+    env['LD_LIBRARY_PATH'] = libdir
+    result = runCmd(cmd, env=env, native_sysroot=sysroot, ignore_status=True, **kwargs)
+    testInst.assertEqual(result.status, 0, "Status not equal to 0. output: %s" % result.output)
+
+
 
 # vim:set ts=4 sw=4 sts=4 expandtab:

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -10,7 +10,6 @@ DEPENDS_append_class-target = "ostree ${@bb.utils.contains('SOTA_CLIENT_FEATURES
 DEPENDS_append_class-native = "glib-2.0-native "
 
 RDEPENDS_${PN}_class-target = "lshw "
-RDEPENDS_${PN}_append_class-target = "${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'hsm', ' engine-pkcs11', '', d)} "
 RDEPENDS_${PN}_append_class-target = " ${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'serialcan', '  slcand-start', '', d)} "
 
 PV = "1.0+git${SRCPV}"
@@ -41,9 +40,9 @@ do_install_append () {
     rm -fr ${D}${libdir}/systemd
 }
 do_install_append_class-target () {
+    rm -f ${D}${bindir}/aktualizr_cert_provider
     rm -f ${D}${bindir}/aktualizr_implicit_writer
     rm -f ${D}${libdir}/sota/sota.toml
-    rm -f ${D}${bindir}/aktualizr_cert_provider
     ${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'secondary-example', '', 'rm -f ${D}${bindir}/example-interface', d)}
     ${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'secondary-isotp-example', '', 'rm -f ${D}${bindir}/isotp-test-interface', d)}
 
@@ -79,6 +78,7 @@ FILES_${PN}_class-target = " \
 FILES_${PN}_append_class-target = " ${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'secondary-example', ' ${bindir}/example-interface', '', d)} "
 FILES_${PN}_append_class-target = " ${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'secondary-isotp-example', ' ${bindir}/isotp-test-interface', '', d)} "
 FILES_${PN}_class-native = " \
+                ${bindir}/aktualizr_cert_provider \
                 ${bindir}/aktualizr_implicit_writer \
                 ${bindir}/garage-deploy \
                 ${bindir}/garage-push \

--- a/recipes-support/libp11/libp11_0.4.7.bb
+++ b/recipes-support/libp11/libp11_0.4.7.bb
@@ -7,6 +7,7 @@ SECTION = "Development/Libraries"
 LICENSE = "LGPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=fad9b3332be894bab9bc501572864b29"
 DEPENDS = "libtool openssl"
+RDEPENDS_${PN} += " opensc"
 
 SRC_URI = "git://github.com/OpenSC/libp11.git \
            file://0001-Workaround-for-a-buggy-version-of-openssl-1.0.2m.patch"


### PR DESCRIPTION
Merge pyro into rocko. This brings in a bunch of work on oe-selftest. There are some minor differences for rocko, but most of the logic is the same. The ovmf patch has been omitted since the fix was upstreamed in rocko.