### PR TITLE
Fix calculate_size in case $SIZE < $MIN

### DIFF
--- a/classes/image_types_ota.bbclass
+++ b/classes/image_types_ota.bbclass
@@ -32,7 +32,7 @@ calculate_size () {
 	fi
 
 	if [ "$SIZE" -lt "$MIN" ]; then
-		$SIZE=$MIN
+		SIZE=$MIN
 	fi
 
 	SIZE=`expr $SIZE \+ $EXTRA`


### PR DESCRIPTION
calculate_size had a typo that made one of the cases fail.  This patch fixes it.

Backported from master.