### PR TITLE
image_types_ota: make default grub.cfg a link to loader/grub.cfg

### DIFF
--- a/classes/image_types_ota.bbclass
+++ b/classes/image_types_ota.bbclass
@@ -78,7 +78,7 @@ IMAGE_CMD_otaimg () {
 
 		if [ "${OSTREE_BOOTLOADER}" = "grub" ]; then
 			mkdir -p ${PHYS_SYSROOT}/boot/grub2
-			touch ${PHYS_SYSROOT}/boot/grub2/grub.cfg
+			ln -s ../loader/grub.cfg ${PHYS_SYSROOT}/boot/grub2/grub.cfg
 		elif [ "${OSTREE_BOOTLOADER}" = "u-boot" ]; then
 			touch ${PHYS_SYSROOT}/boot/loader/uEnv.txt
 		else


### PR DESCRIPTION
/boot/grub2/grub.cfg should reflect the grub.cfg used by the boot process
instead of being an empty file.

uEnv.txt should have a similar logic, but will get to that once I'm sure it will not cause any regression.

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>