### PR TITLE
image_types_ota.bbclass: sync deploy /var with the content from rootfs/var

### DIFF
--- a/classes/image_types_ota.bbclass
+++ b/classes/image_types_ota.bbclass
@@ -96,11 +96,12 @@ IMAGE_CMD_otaimg () {
 
 		ostree admin --sysroot=${PHYS_SYSROOT} deploy ${kargs_list} --os=${OSTREE_OSNAME} ${ostree_target_hash}
 
-		# Copy deployment /home and /var/sota to sysroot
+		# Copy deployment /home and /var to sysroot
 		HOME_TMP=`mktemp -d ${WORKDIR}/home-tmp-XXXXX`
-		tar --xattrs --xattrs-include='*' -C ${HOME_TMP} -xf ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.rootfs.ostree.tar.bz2 ./usr/homedirs ./var/sota ./var/local || true
-		mv ${HOME_TMP}/var/sota ${PHYS_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/ || true
-		mv ${HOME_TMP}/var/local ${PHYS_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/ || true
+		tar --xattrs --xattrs-include='*' -C ${HOME_TMP} -xf ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.rootfs.ostree.tar.bz2 ./usr/homedirs ./var || true
+		# Replace standard deploy /var with the content from the original rootfs
+		rm -rf ${PHYS_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/* || true
+		mv ${HOME_TMP}/var/* ${PHYS_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/ || true
 		# Create /var/sota if it doesn't exist yet
 		mkdir -p ${PHYS_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/sota || true
 		mv ${HOME_TMP}/usr/homedirs/home ${PHYS_SYSROOT}/ || true


### PR DESCRIPTION
As /var gets bind-mounted from deploy /var, the original content from
rootfs/var needs to be duplicated when creating the final ota image,
otherwise the final distro behavior will not be aligned with what gets
produced in the original rootfs.

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>