### PR TITLE
sdimage-sota.wks: remove label as it gets set by image_types_ota

### DIFF
--- a/scripts/lib/wic/canned-wks/sdimage-sota.wks
+++ b/scripts/lib/wic/canned-wks/sdimage-sota.wks
@@ -4,4 +4,4 @@
 # first vfat partition.
 
 part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4096 --size 20
-part / --source otaimage --ondisk mmcblk --fstype=ext4 --label root --align 4096
+part / --source otaimage --ondisk mmcblk --fstype=ext4 --align 4096


### PR DESCRIPTION
image_types_ota already defines the rootfs label when creating the ota
image, so drop label overwrite when creating the sdcard partition.

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>