### PR TITLE
Move sota.env from /usr/lib to /etc

### DIFF
--- a/recipes-sota/aktualizr/environment.inc
+++ b/recipes-sota/aktualizr/environment.inc
@@ -11,7 +11,8 @@ do_install_append() {
     AKTUALIZR_PARAMETERS_VIRTUALSECS="${AKTUALIZR_PARAMETERS_VIRTUALSECS} --secondary-config $sec"
   done
 
-  echo "AKTUALIZR_CMDLINE_PARAMETERS=${AKTUALIZR_PARAMETERS_CONFIGFILE} ${AKTUALIZR_PARAMETERS_LEGACYSEC} ${AKTUALIZR_PARAMETERS_VIRTUALSECS}" > ${D}${libdir}/sota/sota.env
+  install -d ${D}${sysconfdir}/sota
+  echo "AKTUALIZR_CMDLINE_PARAMETERS=${AKTUALIZR_PARAMETERS_CONFIGFILE} ${AKTUALIZR_PARAMETERS_LEGACYSEC} ${AKTUALIZR_PARAMETERS_VIRTUALSECS}" > ${D}${sysconfdir}/sota/sota.env
 }
 
-FILES_${PN}_append = " ${libdir}/sota/sota.env"
+FILES_${PN}_append = " ${sysconfdir}/sota/sota.env"

--- a/recipes-sota/aktualizr/files/aktualizr-serialcan.service
+++ b/recipes-sota/aktualizr/files/aktualizr-serialcan.service
@@ -8,7 +8,7 @@ Requires=network-online.target
 [Service]
 RestartSec=10
 Restart=always
-EnvironmentFile=/usr/lib/sota/sota.env
+EnvironmentFile=/etc/sota/sota.env
 ExecStart=/bin/sh -c "(ip addr | grep can0) && /usr/bin/aktualizr $AKTUALIZR_CMDLINE_PARAMETERS"
 
 [Install]

--- a/recipes-sota/aktualizr/files/aktualizr.service
+++ b/recipes-sota/aktualizr/files/aktualizr.service
@@ -7,7 +7,7 @@ Requires=network-online.target
 [Service]
 RestartSec=10
 Restart=always
-EnvironmentFile=/usr/lib/sota/sota.env
+EnvironmentFile=/etc/sota/sota.env
 ExecStart=/usr/bin/aktualizr $AKTUALIZR_CMDLINE_PARAMETERS
 
 [Install]


### PR DESCRIPTION
The current way for the user to replace the default aktualizr
environment configuration is by copying the original aktualizr.service
to /etc/systemd/system and changing EnvironmentFile to point to a
different file, which is not user friendly.

Change the default environment path from /usr/lib/sota/sota.env to
/etc/sota/sota.env to allow user changes during runtime.

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>