### PR TITLE
Patch systemd-networkd-wait-online when using primary-network-config

### DIFF
--- a/recipes-test/demo-network-config/files/systemd-networkd-wait-online.service.override
+++ b/recipes-test/demo-network-config/files/systemd-networkd-wait-online.service.override
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/lib/systemd/systemd-networkd-wait-online --ignore=enp0s4

--- a/recipes-test/demo-network-config/primary-network-config.bb
+++ b/recipes-test/demo-network-config/primary-network-config.bb
@@ -3,14 +3,20 @@ LICENSE = "CLOSED"
 
 inherit allarch
 
-SRC_URI = "file://25-dhcp-server.network"
+SRC_URI = "file://25-dhcp-server.network \
+           file://systemd-networkd-wait-online.service.override \
+           "
 
 
-FILES_${PN} = "/usr/lib/systemd/network"
+FILES_${PN} = "/usr/lib/systemd/network \
+               /usr/lib/systemd/system/systemd-networkd-wait-online.service.d \
+               "
 
 PR = "1"
 
 do_install() {
     install -d ${D}/usr/lib/systemd/network
     install -m 0644 ${WORKDIR}/25-dhcp-server.network ${D}/usr/lib/systemd/network/
+    install -d ${D}/usr/lib/systemd/system/systemd-networkd-wait-online.service.d
+    install -m 0644 ${WORKDIR}/systemd-networkd-wait-online.service.override ${D}/usr/lib/systemd/system/systemd-networkd-wait-online.service.d/override.conf
 }


### PR DESCRIPTION
The state of the bridge interface is stuck in "Configuring" which locks up the multi-user target for 2 minutes.

With this patch, multi-user does not wait at all for the interface. This might be a bit brutal, so beware!