### PR TITLE
image_types_ostree.bbclass: clean up GARAGE_SIGN_REPO after push

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -214,6 +214,7 @@ IMAGE_CMD_garagesign () {
                 bbwarn "Push to garage repository has failed, retrying"
             fi
         done
+        rm -rf ${GARAGE_SIGN_REPO}
 
         if [ "$push_success" -ne "1" ]; then
             bberror "Couldn't push to garage repository"


### PR DESCRIPTION
Avoid exposing the sign repo after the build is completed.

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>