### PR TITLE
aktualizr: include default configs as part of host-tools

### DIFF
--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -45,6 +45,11 @@ do_install_append () {
     rm -fr ${D}${libdir}/systemd
     rm -f ${D}${libdir}/sota/sota.toml # Only needed for the Debian package
     install -d ${D}${libdir}/sota
+    install -m 0644 ${S}/config/sota_autoprov.toml ${D}/${libdir}/sota/sota_autoprov.toml
+    install -m 0644 ${S}/config/sota_autoprov_primary.toml ${D}/${libdir}/sota/sota_autoprov_primary.toml
+    install -m 0644 ${S}/config/sota_hsm_prov.toml ${D}/${libdir}/sota/sota_hsm_prov.toml
+    install -m 0644 ${S}/config/sota_implicit_prov.toml ${D}/${libdir}/sota/sota_implicit_prov.toml
+    install -m 0644 ${S}/config/sota_implicit_prov_ca.toml ${D}/${libdir}/sota/sota_implicit_prov_ca.toml
     install -m 0644 ${S}/config/sota_secondary.toml ${D}/${libdir}/sota/sota_secondary.toml
     install -d ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/aktualizr-secondary.socket ${D}${systemd_unitdir}/system/aktualizr-secondary.socket
@@ -58,13 +63,6 @@ do_install_append_class-target () {
 }
 
 do_install_append_class-native () {
-    install -d ${D}${libdir}/sota
-    install -m 0644 ${S}/config/sota_autoprov.toml ${D}/${libdir}/sota/sota_autoprov.toml
-    install -m 0644 ${S}/config/sota_autoprov_primary.toml ${D}/${libdir}/sota/sota_autoprov_primary.toml
-    install -m 0644 ${S}/config/sota_hsm_prov.toml ${D}/${libdir}/sota/sota_hsm_prov.toml
-    install -m 0644 ${S}/config/sota_implicit_prov.toml ${D}/${libdir}/sota/sota_implicit_prov.toml
-    install -m 0644 ${S}/config/sota_implicit_prov_ca.toml ${D}/${libdir}/sota/sota_implicit_prov_ca.toml
-
     install -m 0755 ${B}/src/sota_tools/garage-sign-prefix/src/garage-sign/bin/* ${D}${bindir}
     install -m 0644 ${B}/src/sota_tools/garage-sign-prefix/src/garage-sign/lib/* ${D}${libdir}
 }
@@ -93,6 +91,11 @@ FILES_${PN}-host-tools = " \
                 ${bindir}/aktualizr_implicit_writer \
                 ${bindir}/garage-deploy \
                 ${bindir}/garage-push \
+                ${libdir}/sota/sota_autoprov.toml \
+                ${libdir}/sota/sota_autoprov_primary.toml \
+                ${libdir}/sota/sota_hsm_prov.toml \
+                ${libdir}/sota/sota_implicit_prov.toml \
+                ${libdir}/sota/sota_implicit_prov_ca.toml \
                 "
 
 FILES_${PN}-secondary = " \


### PR DESCRIPTION
Provide the default sota configs as part of host-tools so they can be used by aktualizr_cert_provider and aktualizr_implicit_writer.

This pull request depends on #284.