### PR TITLE
Stop forcing Linux 4.4 on qemux86-64

### DIFF
--- a/classes/sota_qemux86-64.bbclass
+++ b/classes/sota_qemux86-64.bbclass
@@ -1,6 +1,3 @@
-# See https://advancedtelematic.atlassian.net/browse/PRO-2693
-PREFERRED_VERSION_linux-yocto_qemux86-64_sota = "4.4%"
-
 IMAGE_FSTYPES_remove = "wic"
 
 # U-Boot support for SOTA


### PR DESCRIPTION
The mentioned issue doesn't seem to exist anymore