### PR TITLE
Feat/garage sign auto version

### DIFF
--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -22,7 +22,7 @@ SRC_URI = " \
   file://aktualizr-secondary.socket \
   file://aktualizr-serialcan.service \
   "
-SRCREV = "930d8eef6eb584686654601c056d7c9c6fca3048"
+SRCREV = "7ccfc5b4286b9a04915e74a7474a8d3451145e1c"
 BRANCH ?= "master"
 
 S = "${WORKDIR}/git"
@@ -36,6 +36,8 @@ SYSTEMD_SERVICE_${PN} = "aktualizr.service"
 SYSTEMD_SERVICE_${PN}-secondary = "aktualizr-secondary.socket"
 
 BBCLASSEXTEND =+ "native"
+
+require garage-sign-version.inc
 
 EXTRA_OECMAKE = "-DWARNING_AS_ERROR=OFF \
                  -DCMAKE_BUILD_TYPE=Release \

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -37,9 +37,17 @@ SYSTEMD_SERVICE_${PN}-secondary = "aktualizr-secondary.socket"
 
 BBCLASSEXTEND =+ "native"
 
-EXTRA_OECMAKE = "-DWARNING_AS_ERROR=OFF -DCMAKE_BUILD_TYPE=Release -DAKTUALIZR_VERSION=${PV} "
-EXTRA_OECMAKE_append_class-target = " -DBUILD_OSTREE=ON -DBUILD_ISOTP=ON ${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'hsm', '-DBUILD_P11=ON', '', d)} "
-EXTRA_OECMAKE_append_class-native = " -DBUILD_SOTA_TOOLS=ON -DBUILD_OSTREE=OFF -DBUILD_SYSTEMD=OFF "
+EXTRA_OECMAKE = "-DWARNING_AS_ERROR=OFF \
+                 -DCMAKE_BUILD_TYPE=Release \
+                 -DAKTUALIZR_VERSION=${PV} "
+EXTRA_OECMAKE_append_class-target = " -DBUILD_OSTREE=ON \
+                                      -DBUILD_ISOTP=ON \
+                                      ${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'hsm', '-DBUILD_P11=ON', '', d)} "
+EXTRA_OECMAKE_append_class-native = " -DBUILD_SOTA_TOOLS=ON \
+                                      -DBUILD_OSTREE=OFF \
+                                      -DBUILD_SYSTEMD=OFF \
+                                      -DGARAGE_SIGN_VERSION=${GARAGE_SIGN_VERSION} \
+                                      -DGARAGE_SIGN_SHA256=${GARAGE_SIGN_SHA256}"
 
 do_install_append () {
     rm -fr ${D}${libdir}/systemd
@@ -65,8 +73,8 @@ do_install_append_class-native () {
     install -m 0644 ${S}/config/sota_implicit_prov.toml ${D}/${libdir}/sota/sota_implicit_prov.toml
     install -m 0644 ${S}/config/sota_implicit_prov_ca.toml ${D}/${libdir}/sota/sota_implicit_prov_ca.toml
 
-    install -m 0755 ${B}/src/sota_tools/garage-sign-prefix/src/garage-sign/bin/* ${D}${bindir}
-    install -m 0644 ${B}/src/sota_tools/garage-sign-prefix/src/garage-sign/lib/* ${D}${libdir}
+    install -m 0755 ${B}/src/sota_tools/garage-sign/bin/* ${D}${bindir}
+    install -m 0644 ${B}/src/sota_tools/garage-sign/lib/* ${D}${libdir}
 }
 
 PACKAGES =+ " ${PN}-common ${PN}-examples ${PN}-host-tools ${PN}-secondary "

--- a/recipes-sota/aktualizr/garage-sign-version.inc
+++ b/recipes-sota/aktualizr/garage-sign-version.inc
@@ -1,0 +1,23 @@
+
+python () {
+    if d.getVar("GARAGE_SIGN_VERSION", True) or not d.getVar("SOTA_PACKED_CREDENTIALS", True):
+        return
+    import json
+    import urllib.request
+    import zipfile
+    with zipfile.ZipFile(d.getVar("SOTA_PACKED_CREDENTIALS", True), 'r') as zip_ref:
+        try:
+            with zip_ref.open('tufrepo.url', mode='r') as url_file:
+                url = url_file.read().decode() + '/health/version'
+        except (KeyError, ValueError, RuntimeError):
+            return
+    r = urllib.request.urlopen(url)
+    if r.code != 200:
+        return
+    resp = r.read()
+    j = json.loads(resp)
+    version = 'cli-' + j['version'] + '.tgz'
+    d.setVar("GARAGE_SIGN_VERSION", version)
+}
+
+# vim:set ts=4 sw=4 sts=4 expandtab:


### PR DESCRIPTION
Set GARAGE_SIGN_VERSION in local.conf to request a specific version, e.g.:
GARAGE_SIGN_VERSION = "cli-0.3.0-5-g5908997.tgz"
If unset, get the server URL out of the credentials, ask what version the server is using, and use that. If the credentials don't have tufrepo.url, the default (latest version) will be used.

Set GARAGE_SIGN_SHA256 in local.conf to specify a hash to check, e.g.:
GARAGE_SIGN_SHA256 = "94f5db1accbbbaa279f7ac5a2e618f5448adeafbe32d6cbc90c8604054ab653e"
If unset, the sha256 is not computed.

Please do not merge this until https://github.com/advancedtelematic/aktualizr/pull/684 is merged and this is updated with the correct aktualizr commit. I've created the PR prematurely in order to solicit review.