### PR TITLE
Add support for custom garage target version and url

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -200,6 +200,12 @@ IMAGE_CMD_garagesign () {
 
         ostree_target_hash=$(cat ${OSTREE_REPO}/refs/heads/${OSTREE_BRANCHNAME})
 
+        # Use OSTree target hash as version if none was provided by the user
+        target_version=${ostree_target_hash}
+        if [ -n "${GARAGE_TARGET_VERSION}" ]; then
+            target_version=${GARAGE_TARGET_VERSION}
+        fi
+
         # Push may fail due to race condition when multiple build machines try to push simultaneously
         #   in which case targets.json should be pulled again and the whole procedure repeated
         push_success=0
@@ -210,9 +216,9 @@ IMAGE_CMD_garagesign () {
                                     --home-dir ${GARAGE_SIGN_REPO} \
                                     --name ${GARAGE_TARGET_NAME} \
                                     --format OSTREE \
-                                    --version ${ostree_target_hash} \
+                                    --version ${target_version} \
                                     --length 0 \
-                                    --url "https://example.com/" \
+                                    --url "${GARAGE_TARGET_URL}" \
                                     --sha256 ${ostree_target_hash} \
                                     --hardwareids ${MACHINE}
             garage-sign targets sign --repo tufrepo \

--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -33,6 +33,8 @@ OSTREE_BOOTLOADER ??= 'u-boot'
 GARAGE_SIGN_REPO ?= "${DEPLOY_DIR_IMAGE}/garage_sign_repo"
 GARAGE_SIGN_KEYNAME ?= "garage-key"
 GARAGE_TARGET_NAME ?= "${OSTREE_BRANCHNAME}"
+GARAGE_TARGET_VERSION ?= ""
+GARAGE_TARGET_URL ?= "https://example.com/"
 
 SOTA_MACHINE ??="none"
 SOTA_MACHINE_rpi ?= "raspberrypi"


### PR DESCRIPTION
Both values can be defined by the user, allowing a custom version id and
URL, which is specially useful for CI builds.

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>