### PR TITLE
layer.conf: add LAYERSERIES_COMPAT markup

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,3 +10,4 @@ BBFILE_PATTERN_sota = "^${LAYERDIR}/"
 BBFILE_PRIORITY_sota = "7"
 
 LAYERDEPENDS_sota = "filesystems-layer"
+LAYERSERIES_COMPAT_sota = "sumo"


### PR DESCRIPTION
Allows the user to easily identify if the layer is compatible with
oe-core.

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>