### PR TITLE
ostree: remove python from rdepends

### DIFF
--- a/recipes-sota/ostree/ostree_git.bb
+++ b/recipes-sota/ostree/ostree_git.bb
@@ -21,8 +21,7 @@ DEPENDS += "attr libarchive glib-2.0 pkgconfig gpgme libgsystem fuse e2fsprogs g
 DEPENDS_append = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', ' systemd', '', d)}"
 DEPENDS_remove_class-native = "systemd-native"
 
-RDEPENDS_${PN} = "python util-linux-libuuid util-linux-libblkid util-linux-libmount libcap bash"
-RDEPENDS_${PN}_remove_class-native = "python-native"
+RDEPENDS_${PN} = "util-linux-libuuid util-linux-libblkid util-linux-libmount libcap bash"
 
 EXTRA_OECONF = "CFLAGS='-Wno-error=missing-prototypes' --with-libarchive --disable-gtk-doc --disable-gtk-doc-html --disable-gtk-doc-pdf --disable-man --with-smack --with-builtin-grub2-mkconfig --with-curl --without-soup"
 EXTRA_OECONF_append_class-native = " --enable-wrpseudo-compat"


### PR DESCRIPTION
Python is not needed by ostree itself (no script or utility using
python), so remove it from the rdepends list.

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>