### PR TITLE
Bugfix/bump aktualizr

### DIFF
--- a/lib/oeqa/selftest/cases/updater.py
+++ b/lib/oeqa/selftest/cases/updater.py
@@ -671,12 +671,12 @@ def akt_native_run(testInst, cmd, **kwargs):
 def verifyProvisioned(testInst, machine):
     # Verify that device HAS provisioned.
     ran_ok = False
-    for delay in [5, 5, 5, 5, 10]:
-        sleep(delay)
+    for delay in [5, 5, 5, 5, 10, 10, 10, 10]:
         stdout, stderr, retcode = testInst.qemu_command('aktualizr-info')
         if retcode == 0 and stderr == b'' and stdout.decode().find('Fetched metadata: yes') >= 0:
             ran_ok = True
             break
+        sleep(delay)
     testInst.assertIn(b'Device ID: ', stdout, 'Provisioning failed: ' + stderr.decode() + stdout.decode())
     testInst.assertIn(b'Primary ecu hardware ID: ' + machine.encode(), stdout,
                   'Provisioning failed: ' + stderr.decode() + stdout.decode())

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -22,7 +22,7 @@ SRC_URI = " \
   file://aktualizr-secondary.socket \
   file://aktualizr-serialcan.service \
   "
-SRCREV = "5fa9a79f1fb29266c862a9a6cb32082bb77844a5"
+SRCREV = "617d6d9242239a5719296f18e207ac4d8d94b7b2"
 BRANCH ?= "master"
 
 S = "${WORKDIR}/git"
@@ -41,7 +41,8 @@ require garage-sign-version.inc
 
 EXTRA_OECMAKE = "-DWARNING_AS_ERROR=OFF \
                  -DCMAKE_BUILD_TYPE=Release \
-                 -DAKTUALIZR_VERSION=${PV} "
+                 -DAKTUALIZR_VERSION=${PV} \
+                 -DBUILD_LOAD_TESTS=OFF"
 EXTRA_OECMAKE_append_class-target = " -DBUILD_OSTREE=ON \
                                       -DBUILD_ISOTP=ON \
                                       ${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'hsm', '-DBUILD_P11=ON', '', d)} "


### PR DESCRIPTION
Now includes the latest changes from https://github.com/advancedtelematic/aktualizr/pull/736 and the load tests.