### PR TITLE
Put extra configs in their own files.

### DIFF
--- a/recipes-sota/config/aktualizr-disable-send-ip.bb
+++ b/recipes-sota/config/aktualizr-disable-send-ip.bb
@@ -7,11 +7,12 @@ LIC_FILES_CHKSUM = "file://${WORKDIR}/LICENSE;md5=9741c346eef56131163e13b9db1241
 
 SRC_URI = " \
             file://LICENSE \
+            file://30-disable-send-ip.toml \
             "
 
 do_install_append () {
     install -m 0700 -d ${D}${libdir}/sota/conf.d
-    echo "[telemetry]\nreport_network = false\n" > ${D}${libdir}/sota/conf.d/30-disable-send-ip.toml
+    install -m 0644 ${WORKDIR}/30-disable-send-ip.toml ${D}${libdir}/sota/conf.d/30-disable-send-ip.toml
 }
 
 FILES_${PN} = " \

--- a/recipes-sota/config/aktualizr-example-interface.bb
+++ b/recipes-sota/config/aktualizr-example-interface.bb
@@ -7,11 +7,12 @@ LIC_FILES_CHKSUM = "file://${WORKDIR}/LICENSE;md5=9741c346eef56131163e13b9db1241
 
 SRC_URI = " \
             file://LICENSE \
+            file://30-example-interface.toml \
             "
 
 do_install_append () {
     install -m 0700 -d ${D}${libdir}/sota/conf.d
-    echo "[uptane]\nlegacy_interface = \"/usr/bin/example-interface\"\n" > ${D}${libdir}/sota/conf.d/30-example-interface.toml
+    install -m 0644 ${WORKDIR}/30-example-interface.toml ${D}${libdir}/sota/conf.d/30-example-interface.toml
 }
 
 FILES_${PN} = " \

--- a/recipes-sota/config/aktualizr-log-debug.bb
+++ b/recipes-sota/config/aktualizr-log-debug.bb
@@ -7,11 +7,12 @@ LIC_FILES_CHKSUM = "file://${WORKDIR}/LICENSE;md5=9741c346eef56131163e13b9db1241
 
 SRC_URI = " \
             file://LICENSE \
+            file://90-log-debug.toml \
             "
 
 do_install_append () {
     install -m 0700 -d ${D}${libdir}/sota/conf.d
-    echo "[logger]\nloglevel = 0\n" > ${D}${libdir}/sota/conf.d/90-log-debug.toml
+    install -m 0644 ${WORKDIR}/90-log-debug.toml ${D}${libdir}/sota/conf.d/90-log-debug.toml
 }
 
 FILES_${PN} = " \

--- a/recipes-sota/config/files/30-disable-send-ip.toml
+++ b/recipes-sota/config/files/30-disable-send-ip.toml
@@ -1,0 +1,2 @@
+[telemetry]
+report_network = false

--- a/recipes-sota/config/files/30-example-interface.toml
+++ b/recipes-sota/config/files/30-example-interface.toml
@@ -1,0 +1,2 @@
+[uptane]
+legacy_interface = "/usr/bin/example-interface"

--- a/recipes-sota/config/files/90-log-debug.toml
+++ b/recipes-sota/config/files/90-log-debug.toml
@@ -1,0 +1,2 @@
+[logger]
+loglevel = 0


### PR DESCRIPTION
This is more reliable and readable than just dumping things with echo. Plus it
is easier for setting permissions, and it fixes some obscure problem with line
endings that only happens on shovel.