### PR TITLE
ostree: set CLEANBROKEN as upstream build system fails to clean

### DIFF
--- a/recipes-sota/ostree/ostree_git.bb
+++ b/recipes-sota/ostree/ostree_git.bb
@@ -15,6 +15,8 @@ PR = "1"
 
 S = "${WORKDIR}/git"
 
+CLEANBROKEN = "1"
+
 BBCLASSEXTEND = "native"
 
 DEPENDS += "attr libarchive glib-2.0 pkgconfig gpgme libgsystem fuse e2fsprogs gtk-doc-native curl xz"


### PR DESCRIPTION
Build fails when bitbake expects to call upstream clean target. Setting
CLEANBROKEN in this situations is the suggested approach to workaround build
failures i.e. when changing SRCREVs is involved.

This PR is against master branch but was tested also against pyro and should apply cleanly to rocko as well. Don't know what merging policies this repo is using and couldn't find a contributor's guide, so feel free to merge wherever applicable or tell me to prepare PR for other branches.