### PR TITLE
ostree: Don't use autotools-brokensep.

### DIFF
--- a/recipes-sota/ostree/ostree_git.bb
+++ b/recipes-sota/ostree/ostree_git.bb
@@ -2,7 +2,7 @@ SUMMARY = "Tool for managing bootable, immutable, versioned filesystem trees"
 LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=5f30f0716dfdd0d91eb439ebec522ec2"
 
-inherit autotools-brokensep pkgconfig systemd gobject-introspection
+inherit autotools pkgconfig systemd gobject-introspection
 
 INHERIT_remove_class-native = "systemd"
 
@@ -49,7 +49,7 @@ export STAGING_LIBDIR
 
 do_configure() {
  unset docdir
- NOCONFIGURE=1 ./autogen.sh
+ NOCONFIGURE=1 "${S}/autogen.sh"
  oe_runconf
 }
 


### PR DESCRIPTION
The only reason we needed it was because of a relative path that I've now made absolute.

This may fix the problem at the root of https://github.com/advancedtelematic/meta-updater/pull/318.