### PR TITLE
Add support for rollback on Raspberry Pi

### DIFF
--- a/classes/sota_raspberrypi.bbclass
+++ b/classes/sota_raspberrypi.bbclass
@@ -18,3 +18,5 @@ KERNEL_DEVICETREE_raspberrypi3_sota ?= " bcm2710-rpi-3-b.dtb overlays/vc4-kms-v3
 
 # Kernel args normally provided by RPi's internal bootloader. Non-updateable
 OSTREE_KERNEL_ARGS_sota ?= " 8250.nr_uarts=1 bcm2708_fb.fbwidth=720 bcm2708_fb.fbheight=480 bcm2708_fb.fbswap=1 vc_mem.mem_base=0x3ec00000 vc_mem.mem_size=0x40000000 dwc_otg.lpm_enable=0 console=ttyS0,115200 usbhid.mousepoll=0 "
+
+SOTA_CLIENT_FEATURES_append = " ubootenv"

--- a/recipes-sota/aktualizr/aktualizr-uboot-env-rollback.bb
+++ b/recipes-sota/aktualizr/aktualizr-uboot-env-rollback.bb
@@ -1,0 +1,23 @@
+SUMMARY = "Aktualizr configuration snippet to enable uboot bootcount function"
+HOMEPAGE = "https://github.com/advancedtelematic/aktualizr"
+SECTION = "base"
+LICENSE = "MPL-2.0"
+LIC_FILES_CHKSUM = "file://${WORKDIR}/LICENSE;md5=9741c346eef56131163e13b9db1241b3"
+DEPENDS = "aktualizr-native"
+RDEPENDS_${PN} = "aktualizr"
+
+SRC_URI = " \
+  file://LICENSE \
+  "
+
+do_install() {
+    install -m 0700 -d ${D}${libdir}/sota/conf.d
+    install -m 0644 ${STAGING_DIR_NATIVE}${libdir}/sota/sota_uboot_env.toml ${D}${libdir}/sota/conf.d/30-rollback.toml
+}
+
+FILES_${PN} = " \
+                ${libdir}/sota/conf.d \
+                ${libdir}/sota/conf.d/30-rollback.toml \
+                "
+
+# vim:set ts=4 sw=4 sts=4 expandtab:

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -12,6 +12,8 @@ DEPENDS_append_class-native = "glib-2.0-native "
 RDEPENDS_${PN}_class-target = "lshw "
 RDEPENDS_${PN}_append_class-target = "${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'serialcan', ' slcand-start', '', d)} "
 RDEPENDS_${PN}_append_class-target = "${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'hsm', ' softhsm softhsm-testtoken', '', d)}"
+RDEPENDS_${PN}_append_class-target = " ${@oe.utils.ifelse(d.getVar('OSTREE_BOOTLOADER', True) == 'u-boot', 'u-boot-fw-utils', '')}"
+RDEPENDS_${PN}_append_class-target = " ${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'ubootenv', '  aktualizr-uboot-env-rollback', '', d)} "
 
 PV = "1.0+git${SRCPV}"
 PR = "7"
@@ -23,7 +25,7 @@ SRC_URI = " \
   file://aktualizr-secondary.socket \
   file://aktualizr-serialcan.service \
   "
-SRCREV = "114dc6c519ca9a605d73ad292821348607d0fa12"
+SRCREV = "9f538a8a411ca917184fe11a6cf92e5ebf9efc61"
 BRANCH ?= "master"
 
 S = "${WORKDIR}/git"
@@ -63,6 +65,7 @@ do_install_append () {
     install -m 0644 ${S}/config/sota_implicit_prov.toml ${D}/${libdir}/sota/sota_implicit_prov.toml
     install -m 0644 ${S}/config/sota_implicit_prov_ca.toml ${D}/${libdir}/sota/sota_implicit_prov_ca.toml
     install -m 0644 ${S}/config/sota_secondary.toml ${D}/${libdir}/sota/sota_secondary.toml
+    install -m 0644 ${S}/config/sota_uboot_env.toml ${D}/${libdir}/sota/sota_uboot_env.toml
     install -d ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/aktualizr-secondary.socket ${D}${systemd_unitdir}/system/aktualizr-secondary.socket
     install -m 0644 ${WORKDIR}/aktualizr-secondary.service ${D}${systemd_unitdir}/system/aktualizr-secondary.service
@@ -109,6 +112,7 @@ FILES_${PN}-host-tools = " \
                 ${libdir}/sota/sota_hsm_prov.toml \
                 ${libdir}/sota/sota_implicit_prov.toml \
                 ${libdir}/sota/sota_implicit_prov_ca.toml \
+                ${libdir}/sota/sota_uboot_env.toml \
                 "
 
 FILES_${PN}-secondary = " \

--- a/recipes-sota/aktualizr/files/aktualizr.service
+++ b/recipes-sota/aktualizr/files/aktualizr.service
@@ -1,8 +1,6 @@
 [Unit]
 Description=Aktualizr SOTA Client
-Wants=network-online.target
-After=network.target network-online.target
-Requires=network-online.target
+After=network.target
 
 [Service]
 RestartSec=10


### PR DESCRIPTION
* Added ubootenv client features that pulls respective configuration snippet
* Allowed aktualizr to run even if there is no network connection. It can pollute the log somewhat, but will let aktualizr acknowledge successful boot even if there is no internet connection. An alternative solution would be to implement yet another binary to acknowledge the boot.
* Aktualizr recipe now points to PR branch to test before merging.