### PR TITLE
Bugfix/implicit and certs master

### DIFF
--- a/lib/oeqa/selftest/cases/updater.py
+++ b/lib/oeqa/selftest/cases/updater.py
@@ -439,8 +439,7 @@ class HsmTests(OESelftestTestCase):
         # Strip off line ending.
         value = stdout.decode()[:-1]
         self.assertEqual(value, machine,
-                         'MACHINE does not match hostname: ' + machine + ', ' + value +
-                         '\nIs tianocore ovmf installed?')
+                         'MACHINE does not match hostname: ' + machine + ', ' + value)
         print(value)
         print('Checking output of aktualizr-info:')
         ran_ok = False

--- a/recipes-sota/aktualizr/aktualizr-auto-prov.bb
+++ b/recipes-sota/aktualizr/aktualizr-auto-prov.bb
@@ -35,7 +35,8 @@ do_install() {
     if [ -n "${SOTA_PACKED_CREDENTIALS}" ]; then
         aktualizr_toml=${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'secondary-network', 'sota_autoprov_primary.toml', 'sota_autoprov.toml', d)}
 
-        install -m 0644 ${STAGING_DIR_NATIVE}${libdir}/sota/${aktualizr_toml} ${D}${libdir}/sota/conf.d/20-sota.toml
+        install -m 0644 ${STAGING_DIR_NATIVE}${libdir}/sota/${aktualizr_toml} \
+            ${D}${libdir}/sota/conf.d/20-${aktualizr_toml}.toml
 
         # deploy SOTA credentials
         if [ -e ${SOTA_PACKED_CREDENTIALS} ]; then
@@ -48,7 +49,7 @@ do_install() {
 
 FILES_${PN} = " \
                 ${libdir}/sota/conf.d \
-                ${libdir}/sota/conf.d/20-sota.toml \
+                ${libdir}/sota/conf.d/20-${aktualizr_toml}.toml \
                 ${localstatedir}/sota \
                 ${localstatedir}/sota/sota_provisioning_credentials.zip \
                 "

--- a/recipes-sota/aktualizr/aktualizr-auto-prov.bb
+++ b/recipes-sota/aktualizr/aktualizr-auto-prov.bb
@@ -1,5 +1,5 @@
 SUMMARY = "Aktualizr configuration for autoprovisioning"
-DESCRIPTION = "Systemd service and configurations for autoprovisioning Aktualizr, the SOTA Client application written in C++"
+DESCRIPTION = "Configuration for automatically provisioning Aktualizr, the SOTA Client application written in C++"
 HOMEPAGE = "https://github.com/advancedtelematic/aktualizr"
 SECTION = "base"
 LICENSE = "MPL-2.0"

--- a/recipes-sota/aktualizr/aktualizr-ca-implicit-prov.bb
+++ b/recipes-sota/aktualizr/aktualizr-ca-implicit-prov.bb
@@ -1,5 +1,5 @@
 SUMMARY = "Aktualizr configuration for implicit provisioning with CA"
-DESCRIPTION = "Systemd service and configurations for implicitly provisioning Aktualizr using externally provided or generated CA"
+DESCRIPTION = "Configuration for implicitly provisioning Aktualizr using externally provided or generated CA"
 
 # WARNING: it is NOT a production solution. The secure way to provision devices is to create certificate request directly on the device
 #  (either with HSM/TPM or with software) and then sign it with a CA stored on a disconnected machine
@@ -36,7 +36,7 @@ do_install() {
         SOTA_CACERT_PATH=${DEPLOY_DIR_IMAGE}/CA/cacert.pem
         SOTA_CAKEY_PATH=${DEPLOY_DIR_IMAGE}/CA/ca.private.pem
         mkdir -p ${DEPLOY_DIR_IMAGE}/CA
-        bbwarn "SOTA_CACERT_PATH is not specified, use default one at $SOTA_CACERT_PATH" 
+        bbwarn "SOTA_CACERT_PATH is not specified, use default one at $SOTA_CACERT_PATH"
 
         if [ ! -f ${SOTA_CACERT_PATH} ]; then
             bbwarn "${SOTA_CACERT_PATH} does not exist, generate a new CA"

--- a/recipes-sota/aktualizr/aktualizr-ca-implicit-prov.bb
+++ b/recipes-sota/aktualizr/aktualizr-ca-implicit-prov.bb
@@ -52,19 +52,20 @@ do_install() {
     fi
 
     install -m 0700 -d ${D}${localstatedir}/sota
-    install -m 0644 ${STAGING_DIR_NATIVE}${libdir}/sota/sota_implicit_prov_ca.toml ${D}${libdir}/sota/conf.d/20-sota.toml
+    install -m 0644 ${STAGING_DIR_NATIVE}${libdir}/sota/sota_implicit_prov_ca.toml \
+        ${D}${libdir}/sota/conf.d/20-sota_implicit_prov_ca.toml
     aktualizr_cert_provider --credentials ${SOTA_PACKED_CREDENTIALS} \
                             --device-ca ${SOTA_CACERT_PATH} \
                             --device-ca-key ${SOTA_CAKEY_PATH} \
                             --root-ca \
                             --server-url \
                             --local ${D}${localstatedir}/sota \
-                            --config ${D}${libdir}/sota/conf.d/20-sota.toml
+                            --config ${STAGING_DIR_NATIVE}${libdir}/sota/sota_implicit_prov_ca.toml
 }
 
 FILES_${PN} = " \
                 ${libdir}/sota/conf.d \
-                ${libdir}/sota/conf.d/20-sota.toml \
+                ${libdir}/sota/conf.d/20-sota_implicit_prov_ca.toml \
                 ${libdir}/sota/root.crt \
                 ${localstatedir}/sota/* \
                 "

--- a/recipes-sota/aktualizr/aktualizr-hsm-prov.bb
+++ b/recipes-sota/aktualizr/aktualizr-hsm-prov.bb
@@ -19,15 +19,19 @@ require credentials.inc
 
 do_install() {
     install -m 0700 -d ${D}${libdir}/sota/conf.d
+    install -m 0644 ${STAGING_DIR_NATIVE}${libdir}/sota/sota_hsm_prov.toml \
+        ${D}${libdir}/sota/conf.d/20-sota_hsm_prov.toml
     if [ -n "${SOTA_PACKED_CREDENTIALS}" ]; then
         aktualizr_implicit_writer -c ${SOTA_PACKED_CREDENTIALS} --no-root-ca \
-            -i ${STAGING_DIR_NATIVE}${libdir}/sota/sota_hsm_prov.toml -o ${D}${libdir}/sota/conf.d/20-sota.toml -p ${D}
+            -i ${STAGING_DIR_NATIVE}${libdir}/sota/sota_hsm_prov.toml \
+            -o ${D}${libdir}/sota/conf.d/30-implicit_server.toml -p ${D}
     fi
 }
 
 FILES_${PN} = " \
                 ${libdir}/sota/conf.d \
-                ${libdir}/sota/conf.d/20-sota.toml \
+                ${libdir}/sota/conf.d/20-sota_hsm_prov.toml \
+                ${libdir}/sota/conf.d/30-implicit_server.toml \
                 "
 
 # vim:set ts=4 sw=4 sts=4 expandtab:

--- a/recipes-sota/aktualizr/aktualizr-hsm-prov.bb
+++ b/recipes-sota/aktualizr/aktualizr-hsm-prov.bb
@@ -1,12 +1,12 @@
 SUMMARY = "Aktualizr configuration with HSM support"
-DESCRIPTION = "Systemd service and configurations for HSM provisioning with Aktualizr, the SOTA Client application written in C++"
+DESCRIPTION = "Configuration for HSM provisioning with Aktualizr, the SOTA Client application written in C++"
 HOMEPAGE = "https://github.com/advancedtelematic/aktualizr"
 SECTION = "base"
 LICENSE = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/LICENSE;md5=9741c346eef56131163e13b9db1241b3"
 
 DEPENDS = "aktualizr-native"
-RDEPENDS_${PN} = "aktualizr softhsm softhsm-testtoken"
+RDEPENDS_${PN} = "aktualizr"
 
 SRC_URI = " \
   file://LICENSE \

--- a/recipes-sota/aktualizr/aktualizr-implicit-prov.bb
+++ b/recipes-sota/aktualizr/aktualizr-implicit-prov.bb
@@ -19,15 +19,19 @@ require credentials.inc
 
 do_install() {
     install -m 0700 -d ${D}${libdir}/sota/conf.d
+    install -m 0644 ${STAGING_DIR_NATIVE}${libdir}/sota/sota_implicit_prov.toml \
+        ${D}${libdir}/sota/conf.d/20-sota_implicit_prov.toml
     if [ -n "${SOTA_PACKED_CREDENTIALS}" ]; then
         aktualizr_implicit_writer -c ${SOTA_PACKED_CREDENTIALS} \
-            -i ${STAGING_DIR_NATIVE}${libdir}/sota/sota_implicit_prov.toml -o ${D}${libdir}/sota/conf.d/20-sota.toml -p ${D}
+            -i ${STAGING_DIR_NATIVE}${libdir}/sota/sota_implicit_prov.toml \
+            -o ${D}${libdir}/sota/conf.d/30-implicit_server.toml -p ${D}
     fi
 }
 
 FILES_${PN} = " \
                 ${libdir}/sota/conf.d \
-                ${libdir}/sota/conf.d/20-sota.toml \
+                ${libdir}/sota/conf.d/20-implicit_prov.toml \
+                ${libdir}/sota/conf.d/30-implicit_server.toml \
                 ${libdir}/sota/root.crt \
                 "
 

--- a/recipes-sota/aktualizr/aktualizr-implicit-prov.bb
+++ b/recipes-sota/aktualizr/aktualizr-implicit-prov.bb
@@ -1,5 +1,5 @@
 SUMMARY = "Aktualizr configuration for implicit provisioning"
-DESCRIPTION = "Systemd service and configurations for implicitly provisioning Aktualizr, the SOTA Client application written in C++"
+DESCRIPTION = "Configuration for implicitly provisioning Aktualizr, the SOTA Client application written in C++"
 HOMEPAGE = "https://github.com/advancedtelematic/aktualizr"
 SECTION = "base"
 LICENSE = "MPL-2.0"

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -23,7 +23,7 @@ SRC_URI = " \
   file://aktualizr-secondary.socket \
   file://aktualizr-serialcan.service \
   "
-SRCREV = "3b89858cf8ce9a8331cc4e6a5d2b5783d2eb7ae9"
+SRCREV = "114dc6c519ca9a605d73ad292821348607d0fa12"
 BRANCH ?= "master"
 
 S = "${WORKDIR}/git"

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -99,6 +99,7 @@ FILES_${PN}-examples = " \
                 "
 
 FILES_${PN}-host-tools = " \
+                ${bindir}/aktualizr-repo \
                 ${bindir}/aktualizr_cert_provider \
                 ${bindir}/aktualizr_implicit_writer \
                 ${bindir}/garage-deploy \

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -10,7 +10,8 @@ DEPENDS_append_class-target = "ostree ${@bb.utils.contains('SOTA_CLIENT_FEATURES
 DEPENDS_append_class-native = "glib-2.0-native "
 
 RDEPENDS_${PN}_class-target = "lshw "
-RDEPENDS_${PN}_append_class-target = " ${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'serialcan', '  slcand-start', '', d)} "
+RDEPENDS_${PN}_append_class-target = "${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'serialcan', ' slcand-start', '', d)} "
+RDEPENDS_${PN}_append_class-target = "${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'hsm', ' softhsm softhsm-testtoken', '', d)}"
 
 PV = "1.0+git${SRCPV}"
 PR = "7"

--- a/recipes-sota/ostree/ostree_git.bb
+++ b/recipes-sota/ostree/ostree_git.bb
@@ -11,7 +11,7 @@ SRC_URI = "gitsm://github.com/ostreedev/ostree.git;branch=master"
 SRCREV="854a823e05d6fe8b610c02c2a71eaeb2bf1e98a6"
 
 PV = "v2017.13"
-PR = "1"
+PR = "2"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-support/ca-certificates/ca-certificates_%.bbappend
+++ b/recipes-support/ca-certificates/ca-certificates_%.bbappend
@@ -1,1 +1,0 @@
-SYSROOT_DIRS += "${sysconfdir}"


### PR DESCRIPTION
There is still a bug (perhaps in Yocto?) where the sysroot doesn't always get filled properly and the HSM/implicit tests fail. Cleaning aktualizr-native fixes it temporarily.