### PR TITLE
Ostree recipe cleanups

### DIFF
--- a/recipes-sota/ostree/ostree_git.bb
+++ b/recipes-sota/ostree/ostree_git.bb
@@ -24,7 +24,8 @@ DEPENDS_remove_class-native = "systemd-native"
 
 RDEPENDS_${PN} = "util-linux-libuuid util-linux-libblkid util-linux-libmount libcap bash"
 
-EXTRA_OECONF = "CFLAGS='-Wno-error=missing-prototypes' --with-libarchive --disable-gtk-doc --disable-gtk-doc-html --disable-gtk-doc-pdf --disable-man --with-smack --with-builtin-grub2-mkconfig --with-curl --without-soup"
+CFLAGS_append = " -Wno-error=missing-prototypes"
+EXTRA_OECONF = "--disable-gtk-doc --disable-man --with-smack --with-builtin-grub2-mkconfig --with-curl --without-soup"
 EXTRA_OECONF_append_class-native = " --enable-wrpseudo-compat"
 
 # Path to ${prefix}/lib/ostree/ostree-grub-generator is hardcoded on the

--- a/recipes-sota/ostree/ostree_git.bb
+++ b/recipes-sota/ostree/ostree_git.bb
@@ -16,10 +16,9 @@ S = "${WORKDIR}/git"
 
 BBCLASSEXTEND = "native"
 
-DEPENDS += "attr libarchive glib-2.0 pkgconfig gpgme libgsystem fuse e2fsprogs gtk-doc-native curl xz"
+DEPENDS += "attr libarchive libcap glib-2.0 gpgme libgsystem fuse e2fsprogs curl xz"
 DEPENDS_append = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', ' systemd', '', d)}"
-
-RDEPENDS_${PN} = "util-linux-libuuid util-linux-libblkid util-linux-libmount libcap bash"
+RDEPENDS_${PN} = "bash"
 
 CFLAGS_append = " -Wno-error=missing-prototypes"
 EXTRA_OECONF = "--disable-gtk-doc --disable-man --with-smack --with-builtin-grub2-mkconfig --with-curl --without-soup"

--- a/recipes-sota/ostree/ostree_git.bb
+++ b/recipes-sota/ostree/ostree_git.bb
@@ -5,8 +5,6 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=5f30f0716dfdd0d91eb439ebec522ec2"
 
 inherit autotools pkgconfig systemd gobject-introspection
 
-INHERIT_remove_class-native = "systemd"
-
 SRC_URI = "gitsm://github.com/ostreedev/ostree.git;branch=master"
 
 SRCREV="854a823e05d6fe8b610c02c2a71eaeb2bf1e98a6"
@@ -20,7 +18,6 @@ BBCLASSEXTEND = "native"
 
 DEPENDS += "attr libarchive glib-2.0 pkgconfig gpgme libgsystem fuse e2fsprogs gtk-doc-native curl xz"
 DEPENDS_append = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', ' systemd', '', d)}"
-DEPENDS_remove_class-native = "systemd-native"
 
 RDEPENDS_${PN} = "util-linux-libuuid util-linux-libblkid util-linux-libmount libcap bash"
 
@@ -35,13 +32,10 @@ SYSROOT_DIR_class-native = "${STAGING_DIR_NATIVE}"
 do_configure[vardeps] += "SYSROOT_DIR"
 
 SYSTEMD_REQUIRED = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}"
-SYSTEMD_REQUIRED_class-native = ""
 
 SYSTEMD_SERVICE_${PN} = "ostree-prepare-root.service ostree-remount.service"
-SYSTEMD_SERVICE_${PN}_class-native = ""
 
 PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', '', d)}"
-PACKAGECONFIG_class-native = ""
 PACKAGECONFIG[systemd] = "--with-systemdsystemunitdir=${systemd_unitdir}/system/ --with-dracut"
 
 FILES_${PN} += "${libdir}/ostree/ ${libdir}/ostbuild"
@@ -86,4 +80,3 @@ PACKAGES =+ "${PN}-switchroot"
 
 FILES_${PN}-switchroot = "${libdir}/ostree/ostree-prepare-root"
 RDEPENDS_${PN}-switchroot = ""
-DEPENDS_remove_class-native = "systemd-native"

--- a/recipes-sota/ostree/ostree_git.bb
+++ b/recipes-sota/ostree/ostree_git.bb
@@ -48,27 +48,27 @@ export STAGING_INCDIR
 export STAGING_LIBDIR
 
 do_configure() {
- unset docdir
- NOCONFIGURE=1 "${S}/autogen.sh"
- oe_runconf
+    unset docdir
+    NOCONFIGURE=1 "${S}/autogen.sh"
+    oe_runconf
 }
 
 do_compile_prepend() {
- export BUILD_SYS="${BUILD_SYS}"
- export HOST_SYS="${HOST_SYS}"
+    export BUILD_SYS="${BUILD_SYS}"
+    export HOST_SYS="${HOST_SYS}"
 }
 
 export SYSTEMD_REQUIRED
 
 do_install_append() {
- if [ -n ${SYSTEMD_REQUIRED} ]; then
-  install -m 0644 -D ${S}/src/boot/ostree-prepare-root.service ${D}${systemd_unitdir}/system/ostree-prepare-root.service
-  install -m 0644 -D ${S}/src/boot/ostree-remount.service ${D}${systemd_unitdir}/system/ostree-remount.service
- fi
+    if [ -n ${SYSTEMD_REQUIRED} ]; then
+        install -m 0644 -D ${S}/src/boot/ostree-prepare-root.service ${D}${systemd_unitdir}/system/ostree-prepare-root.service
+        install -m 0644 -D ${S}/src/boot/ostree-remount.service ${D}${systemd_unitdir}/system/ostree-remount.service
+    fi
 }
 
 do_install_append_class-native() {
-	create_wrapper ${D}${bindir}/ostree OSTREE_GRUB2_EXEC="${STAGING_LIBDIR_NATIVE}/ostree/ostree-grub-generator"
+    create_wrapper ${D}${bindir}/ostree OSTREE_GRUB2_EXEC="${STAGING_LIBDIR_NATIVE}/ostree/ostree-grub-generator"
 }
 
 
@@ -89,4 +89,3 @@ PACKAGES =+ "${PN}-switchroot"
 FILES_${PN}-switchroot = "${libdir}/ostree/ostree-prepare-root"
 RDEPENDS_${PN}-switchroot = ""
 DEPENDS_remove_class-native = "systemd-native"
-

--- a/recipes-sota/ostree/ostree_git.bb
+++ b/recipes-sota/ostree/ostree_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://ostree.readthedocs.io/en/latest/"
 LICENSE = "LGPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=5f30f0716dfdd0d91eb439ebec522ec2"
 
-inherit autotools pkgconfig systemd gobject-introspection
+inherit autotools pkgconfig systemd bash-completion gobject-introspection
 
 SRC_URI = "gitsm://github.com/ostreedev/ostree.git;branch=master"
 
@@ -18,7 +18,7 @@ BBCLASSEXTEND = "native"
 
 DEPENDS += "attr libarchive libcap glib-2.0 gpgme libgsystem fuse e2fsprogs curl xz"
 DEPENDS += "${@bb.utils.filter('DISTRO_FEATURES', 'systemd', d)}"
-RDEPENDS_${PN} = "bash"
+RDEPENDS_${PN}-dracut = "bash"
 
 CFLAGS_append = " -Wno-error=missing-prototypes"
 EXTRA_OECONF = "--disable-gtk-doc --disable-man --with-smack --with-builtin-grub2-mkconfig --with-curl --without-soup"
@@ -35,8 +35,6 @@ do_configure[vardeps] += "SYSROOT_DIR"
 
 SYSTEMD_SERVICE_${PN} = "ostree-prepare-root.service ostree-remount.service"
 
-FILES_${PN} += "${libdir}/ostree/ ${libdir}/ostbuild"
-
 export BUILD_SYS
 export HOST_SYS
 export STAGING_INCDIR
@@ -51,19 +49,21 @@ do_install_append_class-native() {
     create_wrapper ${D}${bindir}/ostree OSTREE_GRUB2_EXEC="${STAGING_LIBDIR_NATIVE}/ostree/ostree-grub-generator"
 }
 
-
-FILES_${PN} += " \
-    ${@bb.utils.contains('DISTRO_FEATURES','systemd','${libdir}/dracut', '', d)} \
-    ${datadir}/gir-1.0 \
-    ${datadir}/gir-1.0/OSTree-1.0.gir \
-    ${libdir}/girepository-1.0 \
-    ${libdir}/girepository-1.0/OSTree-1.0.typelib \
-    ${libdir}/tmpfiles.d/ostree-tmpfiles.conf \
-    ${datadir}/bash-completion/completions/ostree \
-    ${systemd_unitdir}/system-generators/ostree-system-generator \
+PACKAGES += " \
+    ${PN}-switchroot \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'ostree-dracut', '', d)} \
 "
 
-PACKAGES =+ "${PN}-switchroot"
-
+FILES_${PN} = "${bindir} \
+    ${sysconfdir}/ostree \
+    ${datadir}/ostree \
+    ${libdir}/*.so.* \
+    ${libdir}/ostree/ostree-grub-generator \
+    ${libdir}/ostree/ostree-remount \
+    ${libdir}/girepository-1.0/* \
+    ${@bb.utils.contains('DISTRO_FEATURES','systemd','${libdir}/tmpfiles.d', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES','systemd','${systemd_unitdir}/system-generators', '', d)} \
+"
+FILES_${PN}-dev += " ${datadir}/gir-1.0"
+FILES_${PN}-dracut = "${sysconfdir}/dracut.conf.d ${libdir}/dracut"
 FILES_${PN}-switchroot = "${libdir}/ostree/ostree-prepare-root"
-RDEPENDS_${PN}-switchroot = ""

--- a/recipes-sota/ostree/ostree_git.bb
+++ b/recipes-sota/ostree/ostree_git.bb
@@ -45,18 +45,14 @@ PACKAGECONFIG[systemd] = "--with-systemdsystemunitdir=${systemd_unitdir}/system/
 
 FILES_${PN} += "${libdir}/ostree/ ${libdir}/ostbuild"
 
+export BUILD_SYS
+export HOST_SYS
 export STAGING_INCDIR
 export STAGING_LIBDIR
 
-do_configure() {
+do_configure_prepend() {
     unset docdir
     NOCONFIGURE=1 "${S}/autogen.sh"
-    oe_runconf
-}
-
-do_compile_prepend() {
-    export BUILD_SYS="${BUILD_SYS}"
-    export HOST_SYS="${HOST_SYS}"
 }
 
 export SYSTEMD_REQUIRED

--- a/recipes-sota/ostree/ostree_git.bb
+++ b/recipes-sota/ostree/ostree_git.bb
@@ -1,5 +1,6 @@
 SUMMARY = "Tool for managing bootable, immutable, versioned filesystem trees"
-LICENSE = "GPLv2+"
+HOMEPAGE = "https://ostree.readthedocs.io/en/latest/"
+LICENSE = "LGPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=5f30f0716dfdd0d91eb439ebec522ec2"
 
 inherit autotools pkgconfig systemd gobject-introspection


### PR DESCRIPTION
Recipe cleanup, containing:
- fix license description
- reduce amount of local customizations
- remove need for native specific dependencies
- break up into more packages (reduce runtime dependency list when only ostree is required)