### PR TITLE
garage-push: enable verbose logging by default

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -165,7 +165,7 @@ IMAGE_CMD_ostreepush () {
     # Print warnings if credetials are not set or if the file has not been found.
     if [ -n "${SOTA_PACKED_CREDENTIALS}" ]; then
         if [ -e ${SOTA_PACKED_CREDENTIALS} ]; then
-            garage-push --repo=${OSTREE_REPO} \
+            garage-push -vv --repo=${OSTREE_REPO} \
                         --ref=${OSTREE_BRANCHNAME} \
                         --credentials=${SOTA_PACKED_CREDENTIALS} \
                         --cacert=${STAGING_ETCDIR_NATIVE}/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
Make garage-push logs more useful in case of errors when pushing to the
OTA+ server.

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>