### PR TITLE
image_types_ostree: no need to create boot/loader folders when creating ostree repo

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -121,12 +121,6 @@ IMAGE_CMD_ostree () {
         cp ${SOTA_SECONDARY_ECUS} var/sota/ecus
     fi
 
-    # Creating boot directories is required for "ostree admin deploy"
-
-    mkdir -p boot/loader.0
-    mkdir -p boot/loader.1
-    ln -sf boot/loader.0 boot/loader
-
     checksum=`sha256sum ${DEPLOY_DIR_IMAGE}/${OSTREE_KERNEL} | cut -f 1 -d " "`
 
     cp ${DEPLOY_DIR_IMAGE}/${OSTREE_KERNEL} boot/vmlinuz-${checksum}


### PR DESCRIPTION
The boot/loader folders are only required at the deploy stage, which is
already created by image_types_ota.bbclass.

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>