### PR TITLE
First pipeline setup for meta-updater CI

### DIFF
--- a/scripts/ci/Jenkinsfile
+++ b/scripts/ci/Jenkinsfile
@@ -1,0 +1,27 @@
+pipeline {
+  agent any
+  stages {
+    stage('checkout') {
+      steps {
+        checkout([$class: 'RepoScm',
+            manifestRepositoryUrl: 'https://github.com/advancedtelematic/updater-repo',
+            manifestBranch: null,
+            manifestFile: null,
+            manifestGroup: null,
+            mirrorDir: null,
+            jobs: 0,
+            depth: 0,
+            localManifest: null,
+            destinationDir: 'updater-repo',
+            repoUrl: null,
+            currentBranch: false,
+            resetFirst: true,
+            quiet: false,
+            trace: false,
+            showAllChanges: false,
+        ])
+      }
+    }
+  }
+}
+// vim: set ft=groovy tabstop=2 shiftwidth=2 expandtab:

--- a/scripts/ci/Jenkinsfile
+++ b/scripts/ci/Jenkinsfile
@@ -1,12 +1,20 @@
 pipeline {
-  agent any
+  agent none
+  environment {
+    TEST_LOCAL_CONF_APPEND = 'scripts/ci/local.conf.append'
+    TEST_AKTUALIZR_DIR = '.'
+    TEST_AKTUALIZR_BRANCH = 'aktualizr/master'
+  }
   stages {
     stage('checkout') {
+      agent {
+        label 'bitbake'
+      }
       steps {
         checkout([$class: 'RepoScm',
             manifestRepositoryUrl: 'https://github.com/advancedtelematic/updater-repo',
             manifestBranch: null,
-            manifestFile: null,
+            manifestFile: 'master.xml',
             manifestGroup: null,
             mirrorDir: null,
             jobs: 0,
@@ -20,6 +28,23 @@ pipeline {
             trace: false,
             showAllChanges: false,
         ])
+
+        // override meta-updater commit with currently tested branch
+        sh '''
+           META_UPDATER_COMMIT=$(git rev-parse HEAD)
+           cd updater-repo/meta-updater
+           git checkout $META_UPDATER_COMMIT
+           '''
+      }
+    }
+    stage('build-core-image-minimal') {
+      agent {
+        label 'bitbake'
+      }
+      steps {
+        sh 'scripts/ci/configure.sh'
+
+        sh 'scripts/ci/build.sh core-image-minimal'
       }
     }
   }

--- a/scripts/ci/Jenkinsfile
+++ b/scripts/ci/Jenkinsfile
@@ -2,8 +2,8 @@ pipeline {
   agent none
   environment {
     TEST_LOCAL_CONF_APPEND = 'scripts/ci/local.conf.append'
-    TEST_AKTUALIZR_DIR = '.'
-    TEST_AKTUALIZR_BRANCH = 'aktualizr/master'
+    TEST_AKTUALIZR_DIR = 'aktualizr'
+    TEST_AKTUALIZR_BRANCH = 'origin/master'
   }
   stages {
     stage('checkout') {
@@ -11,6 +11,15 @@ pipeline {
         label 'bitbake'
       }
       steps {
+        dir('aktualizr') {
+          checkout([$class: 'GitSCM',
+              userRemoteConfigs: [[url: 'https://github.com/advancedtelematic/aktualizr']],
+              branches: [[name: '*/master']],
+              changelog: true,
+              poll: true,
+          ])
+        }
+
         checkout([$class: 'RepoScm',
             manifestRepositoryUrl: 'https://github.com/advancedtelematic/updater-repo',
             manifestBranch: null,

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+set -x
+
+TEST_MACHINE=${TEST_MACHINE:-qemux86-64}
+TEST_BUILD_DIR=${TEST_BUILD_DIR:-build}
+TEST_REPO_DIR=${TEST_REPO_DIR:-updater-repo}
+
+IMAGE_NAME=${1:-core-image-minimal}
+
+(
+set +euo pipefail
+set +x
+. "${TEST_REPO_DIR}/meta-updater/scripts/envsetup.sh" "${TEST_MACHINE}" "${TEST_BUILD_DIR}"
+
+bitbake "${IMAGE_NAME}"
+)

--- a/scripts/ci/configure.sh
+++ b/scripts/ci/configure.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+set -x
+
+TEST_MACHINE=${TEST_MACHINE:-qemux86-64}
+TEST_BUILD_DIR=${TEST_BUILD_DIR:-build}
+TEST_REPO_DIR=${TEST_REPO_DIR:-updater-repo}
+
+TEST_AKTUALIZR_DIR=${TEST_AKTUALIZR_DIR:-.}
+TEST_LOCAL_CONF_APPEND=${TEST_LOCAL_CONF_APPEND:-}
+TEST_AKTUALIZR_BRANCH=${TEST_AKTUALIZR_BRANCH:-master}
+TEST_AKTUALIZR_REV=${TEST_AKTUALIZR_REV:-$(GIT_DIR="${TEST_AKTUALIZR_DIR}/.git" git rev-parse "${TEST_AKTUALIZR_BRANCH}")}
+
+# remove existing local.conf, keep
+rm -rf "${TEST_BUILD_DIR}/conf.old" || true
+mv "${TEST_BUILD_DIR}/conf" "${TEST_BUILD_DIR}/conf.old" || true
+
+(
+set +euo pipefail
+set +x
+echo ">> Running envsetup.sh"
+. "${TEST_REPO_DIR}/meta-updater/scripts/envsetup.sh" "${TEST_MACHINE}" "${TEST_BUILD_DIR}"
+)
+
+if [[ -n $TEST_LOCAL_CONF_APPEND ]]; then
+    echo ">> Appending to local.conf"
+    REMOTE_AKTUALIZR_BRANCH=$(sed 's#^[^/]*/##g' <<< "$TEST_AKTUALIZR_BRANCH")
+    cat "$TEST_LOCAL_CONF_APPEND" | \
+        sed "s/\$<rev-sha1>/$TEST_AKTUALIZR_REV/g" | \
+        sed "s/\$<rev-branch>/$REMOTE_AKTUALIZR_BRANCH/g" \
+        >> "${TEST_BUILD_DIR}/conf/local.conf"
+fi

--- a/scripts/ci/local.conf.append
+++ b/scripts/ci/local.conf.append
@@ -1,0 +1,5 @@
+SANITY_TESTED_DISTROS = ""
+SRCREV_pn-aktualizr = "$<rev-sha1>"
+SRCREV_pn-aktualizr-native = "${SRCREV_pn-aktualizr}"
+BRANCH_pn-aktualizr = "$<rev-branch>"
+BRANCH_pn-aktualizr-native = "${BRANCH_pn-aktualizr}"


### PR DESCRIPTION
- check out meta-updater and read the Jenkinsfile
- check out aktualizr
- use repo to checkout everything needed for an image build
- move repo's meta-updater commit to the one that triggered CI
- build core-image-minimal

With these properties:

- keep existing workspace between run, so that builds are naturally cached. It might need manual clean intervention sometimes
- a build is triggered when a commit is pushed on aktualizr master, meta-updater master or any branch of a git tracked by repo