### PR TITLE
Offload image creation to wic source plugin (otaimage)

### DIFF
--- a/classes/image_types_ota.bbclass
+++ b/classes/image_types_ota.bbclass
@@ -7,42 +7,10 @@
 # boot scripts, kernel and initramfs images
 #
 
-do_image_otaimg[depends] += "e2fsprogs-native:do_populate_sysroot \
+do_image_otaimg[depends] += " \
 			${@'grub:do_populate_sysroot' if d.getVar('OSTREE_BOOTLOADER', True) == 'grub' else ''} \
 			${@'virtual/bootloader:do_deploy' if d.getVar('OSTREE_BOOTLOADER', True) == 'u-boot' else ''}"
 
-calculate_size () {
-	BASE=$1
-	SCALE=$2
-	MIN=$3
-	MAX=$4
-	EXTRA=$5
-	ALIGN=$6
-
-	SIZE=`echo "$BASE * $SCALE" | bc -l`
-	REM=`echo $SIZE | cut -d "." -f 2`
-	SIZE=`echo $SIZE | cut -d "." -f 1`
-
-	if [ -n "$REM" -o ! "$REM" -eq 0 ]; then
-		SIZE=`expr $SIZE \+ 1`
-	fi
-
-	if [ "$SIZE" -lt "$MIN" ]; then
-		SIZE=$MIN
-	fi
-
-	SIZE=`expr $SIZE \+ $EXTRA`
-	SIZE=`expr $SIZE \+ $ALIGN \- 1`
-	SIZE=`expr $SIZE \- $SIZE \% $ALIGN`
-
-	if [ -n "$MAX" ]; then
-		if [ "$SIZE" -gt "$MAX" ]; then
-			return -1
-		fi
-	fi
-	
-	echo "${SIZE}"
-}
 
 export OSTREE_OSNAME
 export OSTREE_BRANCHNAME
@@ -66,7 +34,9 @@ IMAGE_CMD_otaimg () {
 		fi
 
 
-		PHYS_SYSROOT=`mktemp -d ${WORKDIR}/ota-sysroot-XXXXX`
+		PHYS_SYSROOT=${OSTREE_IMAGE_SYSROOT}
+		rm -rf ${PHYS_SYSROOT} || true
+		mkdir ${PHYS_SYSROOT}
 
 		ostree admin --sysroot=${PHYS_SYSROOT} init-fs ${PHYS_SYSROOT}
 		ostree admin --sysroot=${PHYS_SYSROOT} os-init ${OSTREE_OSNAME}
@@ -115,27 +85,6 @@ IMAGE_CMD_otaimg () {
 
 		rm -rf ${HOME_TMP}
 
-		# Calculate image type
-		OTA_ROOTFS_SIZE=$(calculate_size `du -ks $PHYS_SYSROOT | cut -f 1`  "${IMAGE_OVERHEAD_FACTOR}" "${IMAGE_ROOTFS_SIZE}" "${IMAGE_ROOTFS_MAXSIZE}" `expr ${IMAGE_ROOTFS_EXTRA_SPACE}` "${IMAGE_ROOTFS_ALIGNMENT}")
-
-		if [ $OTA_ROOTFS_SIZE -lt 0 ]; then
-			exit -1
-		fi
-		eval local COUNT=\"0\"
-		eval local MIN_COUNT=\"60\"
-		if [ $OTA_ROOTFS_SIZE -lt $MIN_COUNT ]; then
-			eval COUNT=\"$MIN_COUNT\"
-		fi
-
-		# create image
-		rm -rf ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.otaimg
-		sync
-		dd if=/dev/zero of=${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.otaimg seek=$OTA_ROOTFS_SIZE count=$COUNT bs=1024
-		mkfs.ext4 -O ^64bit ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.otaimg -L otaroot -d ${PHYS_SYSROOT}
-		rm -rf ${PHYS_SYSROOT}
-
-		rm -f ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.otaimg
-		ln -s ${IMAGE_NAME}.otaimg ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.otaimg
 	fi
 }
 

--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -29,6 +29,11 @@ OSTREE_OSNAME ?= "poky"
 OSTREE_INITRAMFS_IMAGE ?= "initramfs-ostree-image"
 OSTREE_BOOTLOADER ??= 'u-boot'
 
+OSTREE_IMAGE_SYSROOT ?= "${WORKDIR}/ota-sysroot"
+OSTREE_IMAGE_SYSROOT[doc] = "The location of the sysroot from which filesystem image is created with otaimage wic source plugin. \
+    The sysroot itself is populated from OSTREE_REPO by otaimg image type."
+WICVARS_append = " OSTREE_IMAGE_SYSROOT"
+
 GARAGE_SIGN_REPO ?= "${DEPLOY_DIR_IMAGE}/garage_sign_repo"
 GARAGE_SIGN_KEYNAME ?= "garage-key"
 GARAGE_TARGET_NAME ?= "${OSTREE_BRANCHNAME}"

--- a/lib/oeqa/selftest/cases/updater.py
+++ b/lib/oeqa/selftest/cases/updater.py
@@ -66,7 +66,7 @@ class GeneralTests(OESelftestTestCase):
     def test_add_package(self):
         deploydir = get_bb_var('DEPLOY_DIR_IMAGE')
         imagename = get_bb_var('IMAGE_LINK_NAME', 'core-image-minimal')
-        image_path = deploydir + '/' + imagename + '.otaimg'
+        image_path = deploydir + '/' + imagename + '.wic'
         logger = logging.getLogger("selftest")
 
         logger.info('Running bitbake with man in the image package list')

--- a/scripts/lib/wic/canned-wks/efiimage-sota.wks
+++ b/scripts/lib/wic/canned-wks/efiimage-sota.wks
@@ -3,6 +3,6 @@
 # can directly dd to boot media.
 
 part /boot --source bootimg-efi --sourceparams="loader=grub-efi" --ondisk hda --label msdos --active --align 1024
-part / --source otaimage --ondisk hda --fstype=ext4 --align 1024 --use-uuid
+part / --source otaimage --ondisk hda --fstype=ext4 --mkfs-extraopts='-F -i 8192 -O ^64bit' --label otaroot --align 1024 --use-uuid
 
 bootloader --ptable gpt --timeout=5 --append="rootfstype=ext4 console=ttyS0,115200 console=tty0" --configfile="grub-ota.cfg"

--- a/scripts/lib/wic/canned-wks/sdimage-sota.wks
+++ b/scripts/lib/wic/canned-wks/sdimage-sota.wks
@@ -4,4 +4,4 @@
 # first vfat partition.
 
 part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4096 --size 20
-part / --source otaimage --ondisk mmcblk --fstype=ext4 --align 4096
+part / --source otaimage --ondisk mmcblk --fstype=ext4 --mkfs-extraopts='-F -i 8192 -O ^64bit' --label otaroot --align 4096


### PR DESCRIPTION
This allows generating sysroot images with different filesystems
transparently and removes the need to do it ourselves.
Options that control filesystem creation are now available
via standard wic options.

One thing to notice is that intermediate result in form of ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.otaimg is not available anymore, but if you need one - you can build it from OSTREE_IMAGE_SYSROOT.