### PR TITLE
aktualizr: bump to latest for key rotation and storage updates (master)

### DIFF
--- a/lib/oeqa/selftest/cases/updater.py
+++ b/lib/oeqa/selftest/cases/updater.py
@@ -226,7 +226,7 @@ class ManualControlTests(OESelftestTestCase):
         Disable the systemd service then run aktualizr manually
         """
         sleep(20)
-        stdout, stderr, retcode = self.qemu_command('aktualizr-info')
+        stdout, stderr, retcode = self.qemu_command('aktualizr-info --allow-migrate')
         self.assertIn(b'Fetched metadata: no', stdout,
                       'Aktualizr should not have run yet' + stderr.decode() + stdout.decode())
 

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -26,7 +26,7 @@ SRC_URI = " \
   file://aktualizr-secondary.socket \
   file://aktualizr-serialcan.service \
   "
-SRCREV = "9207f7534a03a09cbc1e8b9c414070210380cab1"
+SRCREV = "a94a15e31f3b973966b1afc9081fc1b17a3b9d48"
 BRANCH ?= "master"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Work around a bug in oe-selftest with migration and aktualizr-info
interplay by forcing --allow-migrate for now.