### PR TITLE
Allow to use provisioning recipes without aktualizr

### DIFF
--- a/recipes-sota/aktualizr/aktualizr-auto-prov.bb
+++ b/recipes-sota/aktualizr/aktualizr-auto-prov.bb
@@ -5,7 +5,6 @@ SECTION = "base"
 LICENSE = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/LICENSE;md5=9741c346eef56131163e13b9db1241b3"
 DEPENDS = "aktualizr-native zip-native"
-RDEPENDS_${PN} = "aktualizr"
 PV = "1.0"
 PR = "6"
 

--- a/recipes-sota/aktualizr/aktualizr-ca-implicit-prov.bb
+++ b/recipes-sota/aktualizr/aktualizr-ca-implicit-prov.bb
@@ -10,7 +10,6 @@ LICENSE = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/LICENSE;md5=9741c346eef56131163e13b9db1241b3"
 
 DEPENDS = "aktualizr-native openssl-native"
-RDEPENDS_${PN} = "aktualizr"
 
 SRC_URI = " \
   file://LICENSE \

--- a/recipes-sota/aktualizr/aktualizr-hsm-prov.bb
+++ b/recipes-sota/aktualizr/aktualizr-hsm-prov.bb
@@ -6,7 +6,6 @@ LICENSE = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/LICENSE;md5=9741c346eef56131163e13b9db1241b3"
 
 DEPENDS = "aktualizr-native"
-RDEPENDS_${PN} = "aktualizr"
 
 SRC_URI = " \
   file://LICENSE \

--- a/recipes-sota/aktualizr/aktualizr-implicit-prov.bb
+++ b/recipes-sota/aktualizr/aktualizr-implicit-prov.bb
@@ -6,7 +6,6 @@ LICENSE = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/LICENSE;md5=9741c346eef56131163e13b9db1241b3"
 
 DEPENDS = "aktualizr-native"
-RDEPENDS_${PN} = "aktualizr"
 
 SRC_URI = " \
   file://LICENSE \


### PR DESCRIPTION
Allows apps built on top of aktualizr reuse the provisioning recipes.