### PR TITLE
Specify cpu type -host- for KVM mode

### DIFF
--- a/scripts/qemucommand.py
+++ b/scripts/qemucommand.py
@@ -115,7 +115,7 @@ class QemuCommand(object):
         else:
             cmdline.append('-nographic')
         if self.kvm:
-            cmdline.append('-enable-kvm')
+            cmdline += ['-enable-kvm', '-cpu', 'host']
         else:
             cmdline += ['-cpu', 'Haswell']
         if self.overlay:


### PR DESCRIPTION
I'm not sure which cpu type QEMU picks if it's not specified, but I was getting a warning
`qemu-system-x86_64: warning: host doesn't support requested feature: CPUID.80000001H:ECX.svm [bit 2]`
With -cpu host option it will use only supported features and no warning is produced.