### PR TITLE
Provide example for setting UPTANE target version automatically

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -175,7 +175,7 @@ Every time you build an image with `SOTA_PACKED_CREDENTIALS` set, a new entry in
 1. Set `GARAGE_TARGET_VERSION` variable in your `local.conf`.
 2. Write a recipe or a bbclass to write the desired version to `${STAGING_DATADIR_NATIVE}/target_version`. An example of such bbclass can be found in `classes/target_version_example.bbclass`.
 
-Please note that [target name, target version] pairs are expected to be unique in the system. If you build a new target with the same target version as a previously build one, the old package will be overwritten on the update server. It can have unpredictable effect on devices that have this version installed, it is not guaranteed that information will be reported correctly for such devices or that you will be able to update them (we're doing our best though). The easiest way to avoid problems is to make sure that your overriding version is as unique as OSTree commit hash.
+Please note that [target name, target version] pairs are expected to be unique in the system. If you build a new target with the same target version as a previously built one, the old package will be overwritten on the update server. It can have unpredictable effect on devices that have this version installed, and it is not guaranteed that information will be reported correctly for such devices or that you will be able to update them (we're doing our best though). The easiest way to avoid problems is to make sure that your overriding version is as unique as an OSTree commit hash.
 
 == QA with oe-selftest
 

--- a/README.adoc
+++ b/README.adoc
@@ -167,6 +167,16 @@ There are a few settings that can be controlled in `local.conf` to simplify the 
 | `TOOLCHAIN_HOST_TASK_append = " nativesdk-cmake "` | Use with `bitbake -c populate_sdk core-image-minimal` to build an SDK. See the https://github.com/advancedtelematic/aktualizr#developing-against-an-openembedded-system[aktualizr repo] for more information.
 |======================
 
+=== Overriding target version
+*Warning: overriding target version is a dangerous operation, make sure you understand this section completely before doing it.*
+
+Every time you build an image with `SOTA_PACKED_CREDENTIALS` set, a new entry in your Uptane metadata is created and you can see it in the OTA Garage UI if you're using one. Normally this version will be equal to OSTree hash of your root file system. If you want it to be different though you can override is using one of two methods:
+
+1. Set `GARAGE_TARGET_VERSION` variable in your `local.conf`.
+2. Write a recipe or a bbclass to write the desired version to `${STAGING_DATADIR_NATIVE}/target_version`. An example of such bbclass can be found in `classes/target_version_example.bbclass`.
+
+Please note that [target name, target version] pairs are expected to be unique in the system. If you build a new target with the same target version as a previously build one, the old package will be overwritten on the update server. It can have unpredictable effect on devices that have this version installed, it is not guaranteed that information will be reported correctly for such devices or that you will be able to update them (we're doing our best though). The easiest way to avoid problems is to make sure that your overriding version is as unique as OSTree commit hash.
+
 == QA with oe-selftest
 
 This layer relies on the test framework oe-selftest for quality assurance. Follow the steps below to run the tests:

--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -184,7 +184,7 @@ IMAGE_CMD_ostreepush () {
 }
 
 IMAGE_TYPEDEP_garagesign = "ostreepush"
-do_image_garage_sign[depends] += "aktualizr-native:do_populate_sysroot"
+do_image_garagesign[depends] += "aktualizr-native:do_populate_sysroot"
 IMAGE_CMD_garagesign () {
     if [ -n "${SOTA_PACKED_CREDENTIALS}" ]; then
         # if credentials are issued by a server that doesn't support offline signing, exit silently
@@ -210,6 +210,8 @@ IMAGE_CMD_garagesign () {
         target_version=${ostree_target_hash}
         if [ -n "${GARAGE_TARGET_VERSION}" ]; then
             target_version=${GARAGE_TARGET_VERSION}
+        elif [ -e "${STAGING_DATADIR_NATIVE}/target_version" ]; then
+            target_version=$(cat "${STAGING_DATADIR_NATIVE}/target_version")
         fi
 
         # Push may fail due to race condition when multiple build machines try to push simultaneously

--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -210,8 +210,10 @@ IMAGE_CMD_garagesign () {
         target_version=${ostree_target_hash}
         if [ -n "${GARAGE_TARGET_VERSION}" ]; then
             target_version=${GARAGE_TARGET_VERSION}
+            bbwarn "Target version is overriden with GARAGE_TARGET_VERSION variable. It is a dangerous operation, make sure you've read the respective secion in meta-updater/README.adoc"
         elif [ -e "${STAGING_DATADIR_NATIVE}/target_version" ]; then
             target_version=$(cat "${STAGING_DATADIR_NATIVE}/target_version")
+            bbwarn "Target version is overriden with target_version file. It is a dangerous operation, make sure you've read the respective secion in meta-updater/README.adoc"
         fi
 
         # Push may fail due to race condition when multiple build machines try to push simultaneously

--- a/classes/image_types_ota.bbclass
+++ b/classes/image_types_ota.bbclass
@@ -111,6 +111,8 @@ IMAGE_CMD_otaimg () {
 		target_version=${ostree_target_hash}
 		if [ -n "${GARAGE_TARGET_VERSION}" ]; then
 			target_version=${GARAGE_TARGET_VERSION}
+		elif [ -e "${STAGING_DATADIR_NATIVE}/target_version" ]; then
+			target_version=$(cat "${STAGING_DATADIR_NATIVE}/target_version")
 		fi
 		mkdir -p ${PHYS_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/sota/import
 		echo "{\"${ostree_target_hash}\":\"${GARAGE_TARGET_NAME}-${target_version}\"}" > ${PHYS_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/sota/import/installed_versions

--- a/classes/target_version_example.bbclass
+++ b/classes/target_version_example.bbclass
@@ -1,0 +1,11 @@
+# Writes uses repo manifest version as a target version
+#
+
+HOSTTOOLS += " git "
+
+deploy_target_version () {
+  version=$(git --git-dir=${METADIR}/.repo/manifests/.git/ rev-parse HEAD)
+  echo -n ${version} > ${STAGING_DATADIR_NATIVE}/target_version
+}
+
+IMAGE_PREPROCESS_COMMAND += "deploy_target_version;"

--- a/classes/target_version_example.bbclass
+++ b/classes/target_version_example.bbclass
@@ -1,5 +1,4 @@
-# Writes uses repo manifest version as a target version
-#
+# Writes target version to be used by garage-sign
 
 HOSTTOOLS += " git "
 


### PR DESCRIPTION
Making a PR to rocko first because the primary user for that is Spekulatius.

Turns out there is no way to set a bitbake variable from a shell task, so I was choosing between writing a hacky python task calling git via `os.popen()` and adding a hack to `image_types_ostree.bbclass` to read version from a file. The latter seemed cleaner to me.