### PR TITLE
Fix/testtoken openssl bin

### DIFF
--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -26,7 +26,7 @@ SRC_URI = " \
   file://aktualizr-secondary.socket \
   file://aktualizr-serialcan.service \
   "
-SRCREV = "8083d4fa67046689d4bf784b908a048a58457d63"
+SRCREV = "7fc5730719a33c62df394a1fec8488ff5513c90c"
 BRANCH ?= "master"
 
 S = "${WORKDIR}/git"

--- a/recipes-support/openct/openct_%.bbappend
+++ b/recipes-support/openct/openct_%.bbappend
@@ -1,0 +1,2 @@
+pkg_postinst_${PN} () {
+}

--- a/recipes-support/softhsm-testtoken/softhsm-testtoken.bb
+++ b/recipes-support/softhsm-testtoken/softhsm-testtoken.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 inherit systemd
 
-RDEPENDS_${PN} = "softhsm libp11"
+RDEPENDS_${PN} = "softhsm libp11 openssl-bin"
 DEPENDS_append = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', ' systemd', '', d)}"
 
 


### PR DESCRIPTION
Depends on https://github.com/advancedtelematic/aktualizr/pull/947.

I'm going to try to upstream the openct fix.