### PR TITLE
openct: remove unnecessary bbappend.

### DIFF
--- a/recipes-support/openct/openct_%.bbappend
+++ b/recipes-support/openct/openct_%.bbappend
@@ -1,2 +1,0 @@
-pkg_postinst_${PN} () {
-}


### PR DESCRIPTION
This has now been upstreamed to meta-openembedded.