### PR TITLE
Use IMGDEPLOYDIR

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -46,7 +46,7 @@ bitbake agl-demo-platform
 and get as a result an `ostree_repo` folder in your images directory (`tmp/deploy/images/$\{MACHINE}/ostree_repo`). It will contain:
 
 * your OSTree repository, with the rootfs committed as an OSTree deployment,
-* an `otaimg` bootstrap image, which is an OSTree physical sysroot as a burnable filesystem image, and optionally
+* an `ota-ext4` bootstrap image, which is an OSTree physical sysroot as a burnable filesystem image, and optionally
 * some machine-dependent live images (e.g. `.wic` for Raspberry Pi or `.porter-sdimg-ota` Renesas Porter board).
 
 Although `aglsetup.sh` hooks provide reasonable defaults for SOTA-related variables, you may want to tune some of them.

--- a/classes/image_types_ota.bbclass
+++ b/classes/image_types_ota.bbclass
@@ -136,12 +136,8 @@ IMAGE_CMD_ota-ext4 () {
 		eval COUNT=\"$MIN_COUNT\"
 	fi
 
-	rm -rf ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.otaimg
-	sync
-	dd if=/dev/zero of=${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.otaimg seek=${OTA_ROOTFS_SIZE} count=$COUNT bs=1024
-	mkfs.ext4 -O ^64bit ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.otaimg -L otaroot -d ${OTA_SYSROOT}
-	rm -f ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.otaimg
-	ln -s ${IMAGE_NAME}.otaimg ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.otaimg
+	dd if=/dev/zero of=${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.ota-ext4 seek=${OTA_ROOTFS_SIZE} count=$COUNT bs=1024
+	mkfs.ext4 -O ^64bit ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.ota-ext4 -L otaroot -d ${OTA_SYSROOT}
 }
 
 IMAGE_CMD_ota-tar () {

--- a/classes/image_types_ota.bbclass
+++ b/classes/image_types_ota.bbclass
@@ -145,12 +145,7 @@ IMAGE_CMD_ota-ext4 () {
 }
 
 IMAGE_CMD_ota-tar () {
-	rm -rf ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.otaimg.tar
-	tar -cf ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.otaimg.tar -C ${OTA_SYSROOT} .
-	rm -f ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.otaimg.tar
-	ln -s ${IMAGE_NAME}.otaimg.tar ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.otaimg.tar
-	# To fit in with the rest of yocto's image utils, we create a rootfs.ota-tar in the deploy dir
-	cp ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.otaimg.tar ${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.ota-tar
+	tar -cf ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.ota-tar -C ${OTA_SYSROOT} .
 }
 
 do_otasetup[doc] = "Sets up the base ota rootfs used for subsequent image generation"

--- a/lib/oeqa/selftest/cases/updater.py
+++ b/lib/oeqa/selftest/cases/updater.py
@@ -66,7 +66,7 @@ class GeneralTests(OESelftestTestCase):
     def test_add_package(self):
         deploydir = get_bb_var('DEPLOY_DIR_IMAGE')
         imagename = get_bb_var('IMAGE_LINK_NAME', 'core-image-minimal')
-        image_path = deploydir + '/' + imagename + '.otaimg'
+        image_path = deploydir + '/' + imagename + '.ota-ext4'
         logger = logging.getLogger("selftest")
 
         logger.info('Running bitbake with man in the image package list')

--- a/scripts/lib/wic/plugins/source/otaimage.py
+++ b/scripts/lib/wic/plugins/source/otaimage.py
@@ -39,13 +39,13 @@ class OTAImagePlugin(RawCopyPlugin):
         Called to do the actual content population for a partition i.e. it
         'prepares' the partition to be incorporated into the image.
         """
-        bootimg_dir = get_bitbake_var("DEPLOY_DIR_IMAGE")
+        bootimg_dir = get_bitbake_var("IMGDEPLOYDIR")
         if not bootimg_dir:
             logger.error("Couldn't find DEPLOY_DIR_IMAGE, exiting\n")
 
         logger.debug('Bootimg dir: %s' % bootimg_dir)
 
-        src = bootimg_dir + "/" + get_bitbake_var("IMAGE_LINK_NAME") + ".otaimg"
+        src = bootimg_dir + "/" + get_bitbake_var("IMAGE_LINK_NAME") + ".ota-ext4"
 
         logger.debug('Preparing partition using image %s' % (src))
         source_params['file'] = src

--- a/scripts/qemucommand.py
+++ b/scripts/qemucommand.py
@@ -6,7 +6,7 @@ from subprocess import check_output, CalledProcessError
 
 EXTENSIONS = {
     'intel-corei7-64': 'wic',
-    'qemux86-64': 'otaimg'
+    'qemux86-64': 'ota-ext4'
 }
 
 


### PR DESCRIPTION
do_image tasks should not access `DEPLOY_DIR_IMAGE` directly. The `IMGDEPLOYDIR` is properly sstate managed and allows to use the symlinking feature of OpenEmbedded.

To make use some of the features the file ending need to match the image fstype name. That requires us to rename `.otaimg` to `ota-ext4`. This also makes sure that the image is named such that it can be extended to support other file systems etc.

