### PR TITLE
aktualizr: Remove implicit_writer. It is now unused.

### DIFF
--- a/lib/oeqa/selftest/cases/updater.py
+++ b/lib/oeqa/selftest/cases/updater.py
@@ -102,9 +102,6 @@ class AktualizrToolsTests(OESelftestTestCase):
         logger.info('Running bitbake to build aktualizr-native tools')
         bitbake('aktualizr-native')
 
-    def test_implicit_writer_help(self):
-        akt_native_run(self, 'aktualizr_implicit_writer --help')
-
     def test_cert_provider_help(self):
         akt_native_run(self, 'aktualizr_cert_provider --help')
 
@@ -227,6 +224,7 @@ class ManualControlTests(OESelftestTestCase):
         stdout, stderr, retcode = self.qemu_command('aktualizr-info')
         self.assertIn(b'Fetched metadata: yes', stdout,
                       'Aktualizr should have run' + stderr.decode() + stdout.decode())
+
 
 class RpiTests(OESelftestTestCase):
 

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -27,7 +27,7 @@ SRC_URI = " \
   file://aktualizr-serialcan.service \
   "
 
-SRCREV = "39acfec48d1cb91e7621c818ac177f6d3c73fecc"
+SRCREV = "3c1c77c005fc1f872f1e12080528ed6f8a32bbf3"
 BRANCH ?= "master"
 
 S = "${WORKDIR}/git"
@@ -100,7 +100,6 @@ FILES_${PN}-examples = " \
 FILES_${PN}-host-tools = " \
                 ${bindir}/aktualizr-repo \
                 ${bindir}/aktualizr_cert_provider \
-                ${bindir}/aktualizr_implicit_writer \
                 ${bindir}/garage-deploy \
                 ${bindir}/garage-push \
                 ${libdir}/sota/sota_autoprov.toml \


### PR DESCRIPTION
Bump to the latest version as well.

Passes oe-selftest.