### PR TITLE
classes: image_types_ostree: use locking during OSTree repo update

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -155,7 +155,7 @@ IMAGE_CMD_ostree () {
     rm -f ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.rootfs.ostree.tar.bz2
     ln -s ${IMAGE_NAME}.rootfs.ostree.tar.bz2 ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.rootfs.ostree.tar.bz2
 
-    if [ ! -d ${OSTREE_REPO} ]; then
+    if ! ostree --repo=${OSTREE_REPO} refs 2>&1 > /dev/null; then
         ostree --repo=${OSTREE_REPO} init --mode=archive-z2
     fi
 

--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -7,6 +7,7 @@ do_image_ostree[depends] += "ostree-native:do_populate_sysroot \
                         virtual/kernel:do_deploy \
                         ${INITRAMFS_IMAGE}:do_image_complete \
 "
+do_image_ostree[lockfiles] += "${OSTREE_REPO}/ostree.lock"
 
 export OSTREE_REPO
 export OSTREE_BRANCHNAME


### PR DESCRIPTION
The OSTree repository might be shared accross several individual
OSTree builders. Use bitbakes lockfiles mechanism to lock the
OSTree for exclusive use.

Signed-off-by: Stefan Agner <stefan.agner@toradex.com>