### PR TITLE
docs: better explanation of oe-selftest requirements.

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -17,7 +17,7 @@ If you are developing with meta-updater, it may be helpful to read the README an
 
 * OTA-enabled build succeeds for at least one platform, the resulting image boots, and an update can be installed. This check is absolutely necessary for every pull request unless it only touches documentation.
 * If your change touches platform code (like `classes/sota_<platform>.bbclass`), please check building and updating on this particular platform.
-* oe-selftest succeeds. To test meta-updater, run `oe-selftest -r updater` from a build directory with `MACHINE` set to `qemux86-64`.
+* oe-selftest succeeds. To test meta-updater, run `oe-selftest -r updater` from a build directory with `MACHINE` set to `qemux86-64`. See the link:README.adoc#qa-with-oe-selftest[relevant section of the README] for more details.
 * Updates are forwards- and backwards-compatible. You should be able to update an OTA-enabled build before the change is applied to the version with change applied and vice versa. One should pay double attention to the compatibility when bootloader code is affected.
 * The patch/branch should be based on the latest version of the target branch. This may mean that rebasing is necessary if other PRs are merged before yours is approved.
 

--- a/README.adoc
+++ b/README.adoc
@@ -146,7 +146,6 @@ First, you can set `SOTA_CLIENT_PROV` to control which provisioning recipe is us
 
 Second, you can write recipes to install additional config files with customized options. A few recipes already exist to address common needs and provide an example:
 
-* link:recipes-sota/config/aktualizr-example-interface.bb[aktualizr-example-interface.bb] will configure aktualizr to connect to an example interface for a legacy flasher. This is intended to be used in conjunction with the `aktualizr-examples` package. See https://github.com/advancedtelematic/aktualizr/blob/master/docs/legacysecondary.adoc[legacysecondary.adoc] in the aktualizr repo for more information.
 * link:recipes-sota/config/aktualizr-disable-send-ip.bb[aktualizr-disable-send-ip.bb] disables the reporting of networking information to the server. This is enabled by default and supported by https://connect.ota.here.com/[HERE OTA Connect]. However, if you are using a different server that does not support this feature, you may want to disable it in aktualizr.
 * link:recipes-sota/config/aktualizr-log-debug.bb[aktualizr-log-debug.bb] sets the log level of aktualizr to 0 (trace). The default is 2 (info). This recipe is intended for development and debugging purposes.
 
@@ -181,7 +180,7 @@ Please note that [target name, target version] pairs are expected to be unique i
 
 == QA with oe-selftest
 
-This layer relies on the test framework oe-selftest for quality assurance. Follow the steps below to run the tests:
+This layer relies on the test framework oe-selftest for quality assurance. Currently, you will need to run this in a build directory with `MACHINE` set to `qemux86-64`. Follow the steps below to run the tests:
 
 1. Append the line below to `conf/local.conf` to disable the warning about supported operating systems:
 +

--- a/scripts/find_aktualizr_dependencies.sh
+++ b/scripts/find_aktualizr_dependencies.sh
@@ -11,11 +11,12 @@ parentdir="$(dirname "$0")"
 # those are common dependencies not enabled by default.
 ${parentdir}/find_dependencies.py aktualizr
 ${parentdir}/find_dependencies.py aktualizr-auto-prov
-${parentdir}/find_dependencies.py aktualizr-implicit-prov
+${parentdir}/find_dependencies.py aktualizr-auto-prov-creds
 ${parentdir}/find_dependencies.py aktualizr-ca-implicit-prov
+${parentdir}/find_dependencies.py aktualizr-ca-implicit-prov-creds
 ${parentdir}/find_dependencies.py aktualizr-hsm-prov
+${parentdir}/find_dependencies.py aktualizr-hsm-prov-creds
 ${parentdir}/find_dependencies.py aktualizr-disable-send-ip
-${parentdir}/find_dependencies.py aktualizr-example-interface
 ${parentdir}/find_dependencies.py aktualizr-log-debug
 ${parentdir}/find_dependencies.py libp11
 ${parentdir}/find_dependencies.py dpkg


### PR DESCRIPTION
Also remove all references to aktualizr-example-interface. It has been removed.