### PR TITLE
selftest: introduce QEMU_USE_KVM

### DIFF
--- a/lib/oeqa/selftest/cases/updater.py
+++ b/lib/oeqa/selftest/cases/updater.py
@@ -655,7 +655,13 @@ def qemu_launch(efi=False, machine=None, imagename=None):
     args.dir = 'tmp/deploy/images'
     args.efi = efi
     args.machine = machine
-    args.kvm = None  # Autodetect
+    qemu_use_kvm = get_bb_var("QEMU_USE_KVM")
+    if qemu_use_kvm and \
+       (qemu_use_kvm == 'True' and 'x86' in machine or \
+        get_bb_var('MACHINE') in qemu_use_kvm.split()):
+        args.kvm = True
+    else:
+        args.kvm = None  # Autodetect
     args.no_gui = True
     args.gdb = False
     args.pcap = None


### PR DESCRIPTION
The qemucommand.py script uses kvm-ok to determine whether KVM
is available. However, kvm-ok is very Ubuntu specific and not
readily available on Fedora.

Use QEMU_USE_KVM variable which is also used in OpenEmbedded
selftests. The variable must contain True to enable KVM for
machines containing x86 in its name, or contain a list of
machines. For meta-updater this makes sure KVM is used for all
tests:
QEMU_USE_KVM = "intel-corei7-64 qemux86-64"

Signed-off-by: Stefan Agner <stefan.agner@toradex.com>