### PR TITLE
Allow setup custom hardware_id

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -87,6 +87,7 @@ Although we have used U-Boot so far, other boot loaders can be configured work w
 * `SOTA_CLIENT_PROV` - which provisioning method to use. Valid options are https://github.com/advancedtelematic/aktualizr/blob/master/docs/automatic-provisioning.adoc[`aktualizr-auto-prov`], https://github.com/advancedtelematic/aktualizr/blob/master/docs/implicit-provisioning.adoc[`aktualizr-ca-implicit-prov`], and https://github.com/advancedtelematic/aktualizr/blob/master/docs/hsm-provisioning.adoc[`aktualizr-hsm-prov`]. The default is `aktualizr-auto-prov`. This can also be set to an empty string to avoid using a provisioning recipe.
 * `SOTA_CLIENT_FEATURES` - extensions to aktualizr. The only valid options are `hsm` (to build with HSM support) and `secondary-network` (to set up a simulated 'in-vehicle' network with support for a primary node with a DHCP server and a secondary node with a DHCP client).
 * `SOTA_SECONDARY_CONFIG_DIR` - a directory containing JSON configuration files for virtual secondaries on the host. These will be installed into `/etc/sota/ecus` on the device and automatically provided to aktualizr.
+* `SOTA_HARDWARE_ID` - a custom hardware id variable. If not set, - MACHINE variable is used.
 
 == Usage
 

--- a/README.adoc
+++ b/README.adoc
@@ -87,7 +87,7 @@ Although we have used U-Boot so far, other boot loaders can be configured work w
 * `SOTA_CLIENT_PROV` - which provisioning method to use. Valid options are https://github.com/advancedtelematic/aktualizr/blob/master/docs/automatic-provisioning.adoc[`aktualizr-auto-prov`], https://github.com/advancedtelematic/aktualizr/blob/master/docs/implicit-provisioning.adoc[`aktualizr-ca-implicit-prov`], and https://github.com/advancedtelematic/aktualizr/blob/master/docs/hsm-provisioning.adoc[`aktualizr-hsm-prov`]. The default is `aktualizr-auto-prov`. This can also be set to an empty string to avoid using a provisioning recipe.
 * `SOTA_CLIENT_FEATURES` - extensions to aktualizr. The only valid options are `hsm` (to build with HSM support) and `secondary-network` (to set up a simulated 'in-vehicle' network with support for a primary node with a DHCP server and a secondary node with a DHCP client).
 * `SOTA_SECONDARY_CONFIG_DIR` - a directory containing JSON configuration files for virtual secondaries on the host. These will be installed into `/etc/sota/ecus` on the device and automatically provided to aktualizr.
-* `SOTA_HARDWARE_ID` - a custom hardware id variable. If not set, - MACHINE variable is used.
+* `SOTA_HARDWARE_ID` - a custom hardware ID that will be written to the aktualizr config. Defaults to MACHINE if not set.
 
 == Usage
 

--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -235,7 +235,7 @@ IMAGE_CMD_garagesign () {
                                     --length 0 \
                                     --url "${GARAGE_TARGET_URL}" \
                                     --sha256 ${ostree_target_hash} \
-                                    --hardwareids ${MACHINE}
+                                    --hardwareids ${SOTA_HARDWARE_ID}
             garage-sign targets sign --repo tufrepo \
                                      --home-dir ${GARAGE_SIGN_REPO} \
                                      --key-name=targets

--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -11,6 +11,7 @@ HOSTTOOLS_NONFATAL += "java"
 SOTA_CLIENT ??= "aktualizr"
 SOTA_CLIENT_PROV ??= "aktualizr-auto-prov"
 SOTA_DEPLOY_CREDENTIALS ?= "1"
+SOTA_HARDWARE_ID ??= "${MACHINE}"
 
 IMAGE_INSTALL_append_sota = " ostree os-release ${SOTA_CLIENT} ${SOTA_CLIENT_PROV}"
 IMAGE_CLASSES += " image_types_ostree image_types_ota"
@@ -29,7 +30,7 @@ INITRAMFS_FSTYPES ??= "${@oe.utils.ifelse(d.getVar('OSTREE_BOOTLOADER', True) ==
 
 # Please redefine OSTREE_REPO in order to have a persistent OSTree repo
 OSTREE_REPO ?= "${DEPLOY_DIR_IMAGE}/ostree_repo"
-OSTREE_BRANCHNAME ?= "${MACHINE}"
+OSTREE_BRANCHNAME ?= "${SOTA_HARDWARE_ID}"
 OSTREE_OSNAME ?= "poky"
 INITRAMFS_IMAGE ?= "initramfs-ostree-image"
 OSTREE_BOOTLOADER ??= 'u-boot'

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -71,7 +71,7 @@ do_install_append () {
     install -m 0700 -d ${D}${sysconfdir}/sota/conf.d
 
     if [ -n "${SOTA_HARDWARE_ID}" ]; then
-        echo "[uptane]\nprimary_ecu_hardware_id = ${SOTA_HARDWARE_ID}\n" > ${D}${libdir}/sota/conf.d/40-hardware-id.toml
+        echo "[provision]\nprimary_ecu_hardware_id = ${SOTA_HARDWARE_ID}\n" > ${D}${libdir}/sota/conf.d/40-hardware-id.toml
     fi
 
     if [ -n "${SOTA_SECONDARY_CONFIG_DIR}" ]; then

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -70,6 +70,10 @@ do_install_append () {
     install -m 0700 -d ${D}${libdir}/sota/conf.d
     install -m 0700 -d ${D}${sysconfdir}/sota/conf.d
 
+    if [ -n "${SOTA_HARDWARE_ID}" ]; then
+        echo "[uptane]\nprimary_ecu_hardware_id = ${SOTA_HARDWARE_ID}\n" > ${D}${libdir}/sota/conf.d/40-hardware-id.toml
+    fi
+
     if [ -n "${SOTA_SECONDARY_CONFIG_DIR}" ]; then
         if [ -d "${SOTA_SECONDARY_CONFIG_DIR}" ]; then
             install -m 0700 -d ${D}${sysconfdir}/sota/ecus


### PR DESCRIPTION
I was able to build image with custom hardware id.
Image has been successfully provisioned and appeared in the web admin panel.
Also Image successfully has been updated to a new version of image.