### PR TITLE
Fix bloated OTA image

### DIFF
--- a/classes/image_types_ota.bbclass
+++ b/classes/image_types_ota.bbclass
@@ -94,7 +94,7 @@ IMAGE_TYPEDEP_ota-ext4 = "ota"
 do_image_ota_ext4[depends] = "e2fsprogs-native:do_populate_sysroot"
 IMAGE_CMD_ota-ext4 () {
 	# Calculate image type
-	OTA_ROOTFS_SIZE=$(calculate_size `du -ks $OTA_SYSROOT | cut -f 1`  "${IMAGE_OVERHEAD_FACTOR}" "${IMAGE_ROOTFS_SIZE}" "${IMAGE_ROOTFS_MAXSIZE}" `expr ${IMAGE_ROOTFS_EXTRA_SPACE}` "${IMAGE_ROOTFS_ALIGNMENT}")
+	OTA_ROOTFS_SIZE=$(calculate_size `du -ks ${OTA_SYSROOT} | cut -f 1`  "${IMAGE_OVERHEAD_FACTOR}" "${IMAGE_ROOTFS_SIZE}" "${IMAGE_ROOTFS_MAXSIZE}" `expr ${IMAGE_ROOTFS_EXTRA_SPACE}` "${IMAGE_ROOTFS_ALIGNMENT}")
 
 	if [ $OTA_ROOTFS_SIZE -lt 0 ]; then
 		bbfatal "create_ota failed to calculate OTA rootfs size!"


### PR DESCRIPTION
Curly braces are necessary around bitbake variables

Signed-off-by: Anton Gerasimov <anton.gerasimov@here.com>