### PR TITLE
image_types_ostree: use OSTree repo location for lockfiles

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -129,7 +129,7 @@ IMAGE_CMD_ostree () {
 
 IMAGE_TYPEDEP_ostreecommit = "ostree"
 do_image_ostreecommit[depends] += "ostree-native:do_populate_sysroot"
-do_image_ostreecommit[lockfiles] += "${WORKDIR}/${OSTREE_REPO}-commit.lock"
+do_image_ostreecommit[lockfiles] += "${OSTREE_REPO}/ostree.lock"
 IMAGE_CMD_ostreecommit () {
     if ! ostree --repo=${OSTREE_REPO} refs 2>&1 > /dev/null; then
         ostree --repo=${OSTREE_REPO} init --mode=archive-z2


### PR DESCRIPTION
OSTree does not allow concurrent access to the repository. If
two bitbake instances use the same OSTree repository, then they
might access it simultanously. The lockfile to prevent such
simultaneous access should really be in the same location where
the OSTree repository is stored.

Revert back to the location inside the OSTree repository.

Fixes: e97975d6113c ("image_types_ostree/ota.bbclass: refactor ostree task")
Signed-off-by: Stefan Agner <stefan.agner@toradex.com>