### PR TITLE
Use usrmerge

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -1,4 +1,5 @@
 # OSTree deployment
+inherit distro_features_check
 
 OSTREE_KERNEL ??= "${KERNEL_IMAGETYPE}"
 OSTREE_ROOTFS ??= "${WORKDIR}/ostree-rootfs"
@@ -14,6 +15,7 @@ IMAGE_CMD_TAR = "tar --xattrs --xattrs-include=*"
 CONVERSION_CMD_tar = "touch ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type}; ${IMAGE_CMD_TAR} --numeric-owner -cf ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type}.tar -C ${OTA_IMAGE_ROOTFS} . || [ $? -eq 1 ]"
 CONVERSIONTYPES_append = " tar"
 
+REQUIRED_DISTRO_FEATURES = "usrmerge"
 OTA_IMAGE_ROOTFS_task-image-ostree = "${OSTREE_ROOTFS}"
 do_image_ostree[dirs] = "${OSTREE_ROOTFS}"
 do_image_ostree[cleandirs] = "${OSTREE_ROOTFS}"

--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -41,16 +41,6 @@ IMAGE_CMD_ostree () {
     mkdir -p usr/rootdirs
 
     mv etc usr/
-    # Implement UsrMove
-    dirs="bin sbin lib"
-
-    for dir in ${dirs} ; do
-        if [ -d ${dir} ] && [ ! -L ${dir} ] ; then
-            mv ${dir} usr/rootdirs/
-            rm -rf ${dir}
-            ln -sf usr/rootdirs/${dir} ${dir}
-        fi
-    done
 
     if [ -n "${SYSTEMD_USED}" ]; then
         mkdir -p usr/etc/tmpfiles.d

--- a/conf/distro/sota.conf.inc
+++ b/conf/distro/sota.conf.inc
@@ -4,7 +4,7 @@
 #
 # require conf/distro/sota.conf.inc
 
-DISTRO_FEATURES_append = " sota"
+DISTRO_FEATURES_append = " sota usrmerge"
 DISTRO_FEATURES_NATIVE_append = " sota"
 INHERIT += " sota"
 # Prelinking increases the size of downloads and causes build errors

--- a/lib/oeqa/selftest/cases/updater.py
+++ b/lib/oeqa/selftest/cases/updater.py
@@ -36,6 +36,10 @@ class GeneralTests(OESelftestTestCase):
         result = get_bb_var('DISTRO_FEATURES').find('sota')
         self.assertNotEqual(result, -1, 'Feature "sota" not set at DISTRO_FEATURES')
 
+    def test_feature_usrmerge(self):
+        result = get_bb_var('DISTRO_FEATURES').find('usrmerge')
+        self.assertNotEqual(result, -1, 'Feature "sota" not set at DISTRO_FEATURES')
+
     def test_feature_systemd(self):
         result = get_bb_var('DISTRO_FEATURES').find('systemd')
         self.assertNotEqual(result, -1, 'Feature "systemd" not set at DISTRO_FEATURES')


### PR DESCRIPTION
This makes use of the OpenEmbedded feature usrmerge, which implements usrmove at recipe build/package time. We build with usrmerge DISTRO_FEATURE since quite some time, and have not seen a downside here.