### PR TITLE
Make INITRAMFS_FSTYPES an override

### DIFF
--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -21,7 +21,7 @@ WKS_FILE_sota ?= "sdimage-sota.wks"
 
 EXTRA_IMAGEDEPENDS_append_sota = " parted-native mtools-native dosfstools-native"
 
-INITRAMFS_FSTYPES ??= "${@oe.utils.ifelse(d.getVar('OSTREE_BOOTLOADER', True) == 'u-boot', 'cpio.gz.u-boot', 'cpio.gz')}"
+INITRAMFS_FSTYPES_sota ??= "${@oe.utils.ifelse(d.getVar('OSTREE_BOOTLOADER', True) == 'u-boot', 'cpio.gz.u-boot', 'cpio.gz')}"
 
 # Please redefine OSTREE_REPO in order to have a persistent OSTree repo
 export OSTREE_REPO ?= "${DEPLOY_DIR_IMAGE}/ostree_repo"


### PR DESCRIPTION
It is how the other SOTA-specific variables are treated.

Signed-off-by: Anton Gerasimov <anton.gerasimov@here.com>