### PR TITLE
image_garagesign: Use a lock to fix concurrency problems.

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -169,6 +169,9 @@ IMAGE_CMD_ostreepush () {
 
 IMAGE_TYPEDEP_garagesign = "ostreepush"
 do_image_garagesign[depends] += "unzip-native:do_populate_sysroot"
+# This lock solves OTA-1866, which is that removing GARAGE_SIGN_REPO while using
+# garage-sign simultaneously for two images often causes problems.
+do_image_garagesign[lockfiles] += "${DEPLOY_DIR_IMAGE}/garagesign.lock"
 IMAGE_CMD_garagesign () {
     if [ -n "${SOTA_PACKED_CREDENTIALS}" ]; then
         # if credentials are issued by a server that doesn't support offline signing, exit silently


### PR DESCRIPTION
We remove GARAGE_SIGN_REPO at the start and end of this task, which
causes trouble if two images call this task at the same time. This
probably could be fixed in a better fashion (like putting the repo in an
image-specific subdirectory) but this is quick and easy, and the task
usually doesn't take long to run, so the lack of parallelization is not
a big loss.