### PR TITLE
aktualizr: bump to latest 1cad6d10286ade64b24021ca0e23de0d3b64f520

### DIFF
--- a/lib/oeqa/selftest/cases/updater.py
+++ b/lib/oeqa/selftest/cases/updater.py
@@ -214,7 +214,7 @@ class ManualControlTests(OESelftestTestCase):
     def qemu_command(self, command):
         return qemu_send_command(self.qemu.ssh_port, command)
 
-    def test_manual_running_mode_once(self):
+    def test_manual_run_mode_once(self):
         """
         Disable the systemd service then run aktualizr manually
         """
@@ -223,7 +223,7 @@ class ManualControlTests(OESelftestTestCase):
         self.assertIn(b'Can\'t open database', stdout,
                       'Aktualizr should not have run yet' + stderr.decode() + stdout.decode())
 
-        stdout, stderr, retcode = self.qemu_command('aktualizr --running-mode=once')
+        stdout, stderr, retcode = self.qemu_command('aktualizr once')
 
         stdout, stderr, retcode = self.qemu_command('aktualizr-info')
         self.assertIn(b'Fetched metadata: yes', stdout,

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -27,7 +27,7 @@ SRC_URI = " \
   file://aktualizr-serialcan.service \
   "
 
-SRCREV = "d00d1a04cc2366d1a5f143b84b9f507f8bd32c44"
+SRCREV = "1cad6d10286ade64b24021ca0e23de0d3b64f520"
 BRANCH ?= "master"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
- OStree installations are considered complete after a reboot under the new version
- image downloads are not parallelized anymore
- various enhancements and bug fixes

oe-selftests are currently running