### PR TITLE
sota.conf: use reproducible builds by default

### DIFF
--- a/conf/distro/sota.conf.inc
+++ b/conf/distro/sota.conf.inc
@@ -10,4 +10,10 @@ INHERIT += " sota"
 # Prelinking increases the size of downloads and causes build errors
 USER_CLASSES_remove = "image-prelink"
 
+# Enable reproducible builds. Use 0 as mtime, the same as OSTree is using.
+INHERIT += "reproducible_build_simple"
+
+export SOURCE_DATE_EPOCH ?= "0"
+REPRODUCIBLE_TIMESTAMP_ROOTFS ?= "0"
+
 HOSTTOOLS_append = " sync sha256sum"


### PR DESCRIPTION
Use reproducible builds by default. OSTree sets mtime to 0 at
commit time anyway. This makes sure that all mtime timestamps
are 0 already at build time. This is relevant for programs
which relies on mtime of deployed artifacts at runtime.

Python for instance writes the mtime of the source file into
bytecode files (pyc) at build time. When OSTree then clears
the mtime Python considers all bytecode files as stale.

Reproducible binaries also avoid unnecessary differences
between two OSTree commits. E.g. if the sstate cache is
cleared between two OSTree commits OpenEmbedded might create
slightly different binaries.

Note however that not all all recipe generate reproducible
binaries at this time.

Signed-off-by: Stefan Agner <stefan.agner@toradex.com>

This addresses #461.