### PR TITLE
sota.bbclass: fix a variable assignment regression

### DIFF
--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -21,7 +21,7 @@ WKS_FILE_sota ?= "sdimage-sota.wks"
 
 EXTRA_IMAGEDEPENDS_append_sota = " parted-native mtools-native dosfstools-native"
 
-INITRAMFS_FSTYPES ??= "${@oe.utils.ifelse(d.getVar('OSTREE_BOOTLOADER') == 'u-boot', 'cpio.gz.u-boot', 'cpio.gz')}"
+INITRAMFS_FSTYPES ?= "${@oe.utils.ifelse(d.getVar('OSTREE_BOOTLOADER') == 'u-boot', 'cpio.gz.u-boot', 'cpio.gz')}"
 
 # Please redefine OSTREE_REPO in order to have a persistent OSTree repo
 export OSTREE_REPO ?= "${DEPLOY_DIR_IMAGE}/ostree_repo"


### PR DESCRIPTION
A regression was introduced by commit 9dcfcdb9:
[ classes, images: Use standard variables for initramfs ]

it replaced OSTREE_INITRAMFS_IMAGE with INITRAMFS_FSTYPES which is
fine, but the '??=' should be changed to "?=" as well, or else it will
not take effect since INITRAMFS_FSTYPES's already set in bitbake.conf
with '?='.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>