### PR TITLE
image_types_ostree: Add a unique ref to fix simultaneous bitbaking.

### DIFF
--- a/classes/image_types_ota.bbclass
+++ b/classes/image_types_ota.bbclass
@@ -59,7 +59,7 @@ IMAGE_CMD_ota () {
 		bbfatal "Invalid bootloader: ${OSTREE_BOOTLOADER}"
 	fi
 
-	ostree_target_hash=$(cat ${OSTREE_REPO}/refs/heads/${OSTREE_BRANCHNAME})
+	ostree_target_hash=$(cat ${OSTREE_REPO}/refs/heads/${OSTREE_BRANCHNAME}-${IMAGE_BASENAME})
 
 	ostree --repo=${OTA_SYSROOT}/ostree/repo pull-local --remote=${OSTREE_OSNAME} ${OSTREE_REPO} ${ostree_target_hash}
 	kargs_list=""


### PR DESCRIPTION
To enable simultaneous bitbaking of two images with the same branch name, create
a new ref in the OSTree repo using the basename of the image.

As @OYTIS has pointed out, this probably won't solve every problem that might
come up with simultaneous bitbaking, such as if the two images use different
bootloaders. However, it does solve the immediate problem that comes up with our
primary-image + secondary-image example.