### PR TITLE
aktualizr-auto-prov-creds: remove API Gateway URL if it exists.

### DIFF
--- a/recipes-sota/aktualizr/aktualizr-auto-prov-creds.bb
+++ b/recipes-sota/aktualizr/aktualizr-auto-prov-creds.bb
@@ -11,9 +11,14 @@ require credentials.inc
 do_install() {
     if [ -n "${SOTA_PACKED_CREDENTIALS}" ]; then
         install -m 0700 -d ${D}${localstatedir}/sota
-        cp ${SOTA_PACKED_CREDENTIALS} ${D}${localstatedir}/sota/sota_provisioning_credentials.zip
+        cp "${SOTA_PACKED_CREDENTIALS}" ${D}${localstatedir}/sota/sota_provisioning_credentials.zip
         # Device should not be able to push data to treehub
         zip -d ${D}${localstatedir}/sota/sota_provisioning_credentials.zip treehub.json
+        # Device has no use for the API Gateway. Remove if present. See:
+        # https://github.com/advancedtelematic/ota-plus-server/pull/1913/
+        if unzip -l ${D}${localstatedir}/sota/sota_provisioning_credentials.zip api_gateway.url > /dev/null; then
+            zip -d ${D}${localstatedir}/sota/sota_provisioning_credentials.zip api_gateway.url 
+        fi
     fi
 }
 


### PR DESCRIPTION
It will only be used by garage-sign.

See https://github.com/advancedtelematic/ota-plus-server/pull/1913.