### PR TITLE
Backport/thud/auto reboot etc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -151,6 +151,7 @@ First, you can set `SOTA_CLIENT_PROV` to control which provisioning recipe is us
 
 Second, you can write recipes to install additional config files with customized options. A few recipes already exist to address common needs and provide an example:
 
+* link:recipes-sota/config/aktualizr-auto-reboot.bb[aktualizr-auto-reboot.bb] configures aktualizr to automatically reboot after new updates are installed in order to apply the updates immediately. This is only relevant for package managers (such as OSTree) that require a reboot to complete the installation process. If this is not enabled, you will need to reboot the system through other means.
 * link:recipes-sota/config/aktualizr-disable-send-ip.bb[aktualizr-disable-send-ip.bb] disables the reporting of networking information to the server. This is enabled by default and supported by https://connect.ota.here.com/[HERE OTA Connect]. However, if you are using a different server that does not support this feature, you may want to disable it in aktualizr.
 * link:recipes-sota/config/aktualizr-log-debug.bb[aktualizr-log-debug.bb] sets the log level of aktualizr to 0 (trace). The default is 2 (info). This recipe is intended for development and debugging purposes.
 

--- a/classes/image_types_ota.bbclass
+++ b/classes/image_types_ota.bbclass
@@ -59,7 +59,7 @@ IMAGE_CMD_ota () {
 		bbfatal "Invalid bootloader: ${OSTREE_BOOTLOADER}"
 	fi
 
-	ostree_target_hash=$(cat ${OSTREE_REPO}/refs/heads/${OSTREE_BRANCHNAME})
+	ostree_target_hash=$(cat ${OSTREE_REPO}/refs/heads/${OSTREE_BRANCHNAME}-${IMAGE_BASENAME})
 
 	ostree --repo=${OTA_SYSROOT}/ostree/repo pull-local --remote=${OSTREE_OSNAME} ${OSTREE_REPO} ${ostree_target_hash}
 	kargs_list=""

--- a/conf/include/bblayers/sota_am335x-evm.inc
+++ b/conf/include/bblayers/sota_am335x-evm.inc
@@ -1,2 +1,1 @@
-
-BBLAYERS += " ${METADIR}/meta-ti "
+BBLAYERS += "${METADIR}/meta-ti"

--- a/conf/include/bblayers/sota_intel-corei7-64.inc
+++ b/conf/include/bblayers/sota_intel-corei7-64.inc
@@ -1,2 +1,2 @@
-
-BBLAYERS += " ${METADIR}/meta-updater-minnowboard ${METADIR}/meta-intel "
+BBLAYERS += "${METADIR}/meta-updater-minnowboard"
+BBLAYERS += "${METADIR}/meta-intel"

--- a/conf/include/bblayers/sota_m3ulcb.inc
+++ b/conf/include/bblayers/sota_m3ulcb.inc
@@ -1,2 +1,3 @@
-
-BBLAYERS += " ${METADIR}/meta-renesas ${METADIR}/meta-renesas-rcar-gen3 ${METADIR}/meta-openembedded/meta-multimedia"
+BBLAYERS += "${METADIR}/meta-renesas"
+BBLAYERS += "${METADIR}/meta-renesas-rcar-gen3"
+BBLAYERS += "${METADIR}/meta-openembedded/meta-multimedia"

--- a/conf/include/bblayers/sota_porter.inc
+++ b/conf/include/bblayers/sota_porter.inc
@@ -1,2 +1,4 @@
-
-BBLAYERS += " ${METADIR}/meta-renesas ${METADIR}/meta-renesas/meta-rcar-gen2 ${METADIR}/meta-openembedded/meta-multimedia ${METADIR}/meta-updater-porter"
+BBLAYERS += "${METADIR}/meta-renesas"
+BBLAYERS += "${METADIR}/meta-renesas/meta-rcar-gen2"
+BBLAYERS += "${METADIR}/meta-openembedded/meta-multimedia"
+BBLAYERS += "${METADIR}/meta-updater-porter"

--- a/conf/include/bblayers/sota_qemux86-64.inc
+++ b/conf/include/bblayers/sota_qemux86-64.inc
@@ -1,1 +1,1 @@
-BBLAYERS += " ${METADIR}/meta-updater-qemux86-64 " 
+BBLAYERS += "${METADIR}/meta-updater-qemux86-64"

--- a/conf/include/bblayers/sota_raspberrypi2.inc
+++ b/conf/include/bblayers/sota_raspberrypi2.inc
@@ -1,3 +1,3 @@
-BBLAYERS += " ${METADIR}/meta-openembedded/meta-python "
-
-BBLAYERS += " ${METADIR}/meta-updater-raspberrypi ${METADIR}/meta-raspberrypi " 
+BBLAYERS += "${METADIR}/meta-openembedded/meta-python"
+BBLAYERS += "${METADIR}/meta-updater-raspberrypi"
+BBLAYERS += "${METADIR}/meta-raspberrypi"

--- a/conf/include/bblayers/sota_raspberrypi3.inc
+++ b/conf/include/bblayers/sota_raspberrypi3.inc
@@ -1,3 +1,3 @@
-BBLAYERS += " ${METADIR}/meta-openembedded/meta-python "
-
-BBLAYERS += " ${METADIR}/meta-updater-raspberrypi ${METADIR}/meta-raspberrypi " 
+BBLAYERS += "${METADIR}/meta-openembedded/meta-python"
+BBLAYERS += "${METADIR}/meta-updater-raspberrypi"
+BBLAYERS += "${METADIR}/meta-raspberrypi"

--- a/lib/oeqa/selftest/cases/updater.py
+++ b/lib/oeqa/selftest/cases/updater.py
@@ -67,35 +67,6 @@ class GeneralTests(OESelftestTestCase):
         self.assertEqual(result.status, 0,
                          "Java not found. Do you have a JDK installed on your host machine?")
 
-    def test_add_package(self):
-        deploydir = get_bb_var('DEPLOY_DIR_IMAGE')
-        imagename = get_bb_var('IMAGE_LINK_NAME', 'core-image-minimal')
-        image_path = deploydir + '/' + imagename + '.ota-ext4'
-        logger = logging.getLogger("selftest")
-
-        logger.info('Running bitbake with man in the image package list')
-        self.append_config('IMAGE_INSTALL_append = " man "')
-        bitbake('-c cleanall man-db')
-        bitbake('core-image-minimal')
-        result = runCmd('oe-pkgdata-util find-path /usr/bin/man')
-        self.assertEqual(result.output, 'man-db: /usr/bin/man')
-        path1 = os.path.realpath(image_path)
-        size1 = os.path.getsize(path1)
-        logger.info('First image %s has size %i' % (path1, size1))
-
-        logger.info('Running bitbake without man in the image package list')
-        self.append_config('IMAGE_INSTALL_remove = " man "')
-        bitbake('-c cleanall man-db')
-        bitbake('core-image-minimal')
-        result = runCmd('oe-pkgdata-util find-path /usr/bin/man', ignore_status=True)
-        self.assertEqual(result.status, 1, "Status different than 1. output: %s" % result.output)
-        self.assertEqual(result.output, 'ERROR: Unable to find any package producing path /usr/bin/man')
-        path2 = os.path.realpath(image_path)
-        size2 = os.path.getsize(path2)
-        logger.info('Second image %s has size %i', path2, size2)
-        self.assertNotEqual(path1, path2, "Image paths are identical; image was not rebuilt.")
-        self.assertNotEqual(size1, size2, "Image sizes are identical; image was not rebuilt.")
-
 
 class AktualizrToolsTests(OESelftestTestCase):
 

--- a/recipes-sota/aktualizr/aktualizr-auto-prov-creds.bb
+++ b/recipes-sota/aktualizr/aktualizr-auto-prov-creds.bb
@@ -11,9 +11,14 @@ require credentials.inc
 do_install() {
     if [ -n "${SOTA_PACKED_CREDENTIALS}" ]; then
         install -m 0700 -d ${D}${localstatedir}/sota
-        cp ${SOTA_PACKED_CREDENTIALS} ${D}${localstatedir}/sota/sota_provisioning_credentials.zip
+        cp "${SOTA_PACKED_CREDENTIALS}" ${D}${localstatedir}/sota/sota_provisioning_credentials.zip
         # Device should not be able to push data to treehub
         zip -d ${D}${localstatedir}/sota/sota_provisioning_credentials.zip treehub.json
+        # Device has no use for the API Gateway. Remove if present. See:
+        # https://github.com/advancedtelematic/ota-plus-server/pull/1913/
+        if unzip -l ${D}${localstatedir}/sota/sota_provisioning_credentials.zip api_gateway.url > /dev/null; then
+            zip -d ${D}${localstatedir}/sota/sota_provisioning_credentials.zip api_gateway.url 
+        fi
     fi
 }
 

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -23,7 +23,7 @@ SRC_URI = " \
   file://aktualizr-serialcan.service \
   "
 
-SRCREV = "2aa9d93ccea09ec327789eecf858de561ef632da"
+SRCREV = "c71ec0a320d85a3e75ba37bff7dc40ad02e9d655"
 BRANCH ?= "master"
 
 S = "${WORKDIR}/git"

--- a/recipes-sota/config/aktualizr-auto-reboot.bb
+++ b/recipes-sota/config/aktualizr-auto-reboot.bb
@@ -1,0 +1,21 @@
+SUMMARY = "Enable auto reboot to apply updates"
+DESCRIPTION = "Configures aktualizr to auto reboot just after new updates installation in order to apply them"
+HOMEPAGE = "https://github.com/advancedtelematic/aktualizr"
+SECTION = "base"
+LICENSE = "MPL-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
+
+SRC_URI = " \
+            file://35-enable-auto-reboot.toml \
+            "
+
+do_install_append () {
+    install -m 0700 -d ${D}${libdir}/sota/conf.d
+    install -m 0644 ${WORKDIR}/35-enable-auto-reboot.toml ${D}${libdir}/sota/conf.d/35-enable-auto-reboot.toml
+}
+
+FILES_${PN} = " \
+                ${libdir}/sota/conf.d/35-enable-auto-reboot.toml \
+                "
+
+# vim:set ts=4 sw=4 sts=4 expandtab:

--- a/recipes-sota/config/aktualizr-auto-reboot.bb
+++ b/recipes-sota/config/aktualizr-auto-reboot.bb
@@ -1,5 +1,5 @@
 SUMMARY = "Enable auto reboot to apply updates"
-DESCRIPTION = "Configures aktualizr to auto reboot just after new updates installation in order to apply them"
+DESCRIPTION = "Configures aktualizr to automatically reboot after new updates are installed in order to apply the updates immediately"
 HOMEPAGE = "https://github.com/advancedtelematic/aktualizr"
 SECTION = "base"
 LICENSE = "MPL-2.0"

--- a/recipes-sota/config/files/35-enable-auto-reboot.toml
+++ b/recipes-sota/config/files/35-enable-auto-reboot.toml
@@ -1,0 +1,2 @@
+[uptane]
+force_install_completion = true


### PR DESCRIPTION
* Bump to latest aktualizr.
* Add recipe for automatic reboot after installation.
* More robust fix for simultaneous bitbaking.
* Remove API Gateway URL if present before putting credentials on a device.

Note that simply merging master into thud is no longer possible because of the meta-python change, which we don't want in thud.