### PR TITLE
Move warning about insecure practise to the correct recipe

### DIFF
--- a/recipes-sota/aktualizr/aktualizr-ca-implicit-prov-creds.bb
+++ b/recipes-sota/aktualizr/aktualizr-ca-implicit-prov-creds.bb
@@ -3,6 +3,10 @@ SECTION = "base"
 LICENSE = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
 
+# WARNING: it is NOT a production solution. The secure way to provision devices
+# is to create certificate request directly on the device (either with HSM/TPM
+# or with software) and then sign it with a CA stored on a disconnected machine.
+
 DEPENDS = "aktualizr aktualizr-native"
 ALLOW_EMPTY_${PN} = "1"
 

--- a/recipes-sota/aktualizr/aktualizr-ca-implicit-prov.bb
+++ b/recipes-sota/aktualizr/aktualizr-ca-implicit-prov.bb
@@ -1,9 +1,6 @@
 SUMMARY = "Aktualizr configuration for implicit provisioning with CA"
 DESCRIPTION = "Configuration for implicitly provisioning Aktualizr using externally provided or generated CA"
 
-# WARNING: it is NOT a production solution. The secure way to provision devices is to create certificate request directly on the device
-#  (either with HSM/TPM or with software) and then sign it with a CA stored on a disconnected machine
-
 HOMEPAGE = "https://github.com/advancedtelematic/aktualizr"
 SECTION = "base"
 LICENSE = "MPL-2.0"


### PR DESCRIPTION
When SOTA_DEPLOY_CREDENTIALS got introduced deployment of the
provisioning credientials has been moved to
aktualizr-ca-implicit-prov-creds. Move the warning accordingly.

Signed-off-by: Stefan Agner <stefan.agner@toradex.com>