### PR TITLE
ptest for aktualizr

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -219,6 +219,19 @@ oe-selftest --run-tests updater
 
 For more information about oe-selftest, including details about how to run individual test modules or classes, please refer to the https://wiki.yoctoproject.org/wiki/Oe-selftest[Yocto Project wiki].
 
+== Aktualizr test suite with ptest
+
+The meta-updater layer includes support for running parts of the aktualizr test suite on deployed devices through link:https://wiki.yoctoproject.org/wiki/Ptest[Yocto's ptest functionality]. Since it adds significant build time cost, it is currently disabled by default. To enable it, add the following to your `conf/local.conf`:
+
+```
+PTEST_ENABLED_pn-aktualizr = "1"
+IMAGE_INSTALL_append += " aktualizr-ptest ptest-runner "
+```
+
+Be aware that it will add several hundreds of MB to the generated file system.
+
+The aktualizr tests will now be part of the deployed ptest suite, which can be run by calling `ptest-runner`. Alternatively, the required files and run script can be found in `/usr/lib/aktualizr/ptest`.
+
 == Manual provisoning
 
 As described in <<sota-related-variables-in-localconf,SOTA-related variables in local.conf>> section you can set `SOTA_DEPLOY_CREDENTIALS` to `0` to prevent deploying credentials to the built `wic` image. In this case you get a generic image that you can use e.g. on a production line to flash a series of devices. The cost of this approach is that this image is half-baked and should be provisioned before it can connect to the backend.

--- a/lib/oeqa/selftest/cases/updater.py
+++ b/lib/oeqa/selftest/cases/updater.py
@@ -191,7 +191,7 @@ class ManualControlTests(OESelftestTestCase):
         """
         sleep(20)
         stdout, stderr, retcode = self.qemu_command('aktualizr-info')
-        self.assertIn(b'Can\'t open database', stdout,
+        self.assertIn(b'Can\'t open database', stderr,
                       'Aktualizr should not have run yet' + stderr.decode() + stdout.decode())
 
         stdout, stderr, retcode = self.qemu_command('aktualizr once')

--- a/recipes-devtools/valgrind/files/bug344802-unhandled-0xec510f1e.patch
+++ b/recipes-devtools/valgrind/files/bug344802-unhandled-0xec510f1e.patch
@@ -1,0 +1,250 @@
+diff --git a/VEX/priv/guest_arm_defs.h b/VEX/priv/guest_arm_defs.h
+index 2ccbe4398..90312fbd4 100644
+--- a/VEX/priv/guest_arm_defs.h
++++ b/VEX/priv/guest_arm_defs.h
+@@ -350,6 +350,10 @@ typedef
+    }
+    ARMCondcode;
+ 
++extern UInt arm_dirtyhelper_MRS_CNTFRQ ( void );
++extern ULong arm_dirtyhelper_MRRS_CNTVCT ( void );
++extern ULong arm_dirtyhelper_MRRS_CNTPCT ( void );
++
+ #endif /* ndef __VEX_GUEST_ARM_DEFS_H */
+ 
+ /*---------------------------------------------------------------*/
+diff --git a/VEX/priv/guest_arm_helpers.c b/VEX/priv/guest_arm_helpers.c
+index 8a028736e..89b17ce7b 100644
+--- a/VEX/priv/guest_arm_helpers.c
++++ b/VEX/priv/guest_arm_helpers.c
+@@ -1445,6 +1445,53 @@ VexGuestLayout
+         };
+ 
+ 
++UInt arm_dirtyhelper_MRS_CNTFRQ ( void )
++{
++#if   __ARM_ARCH_ISA_ARM  //{
++   UInt w = 0x55555555UL; /* overwritten */
++   __asm__ __volatile__("mrc p15, 0, %0, c14, c0, 0" : "=r"(w));
++   return w;
++#elif __ARM_ARCH_ISA_A64  //}{
++   UInt w;
++   __asm__ __volatile__("mrs %0,cntfrq_el0": "=r"(w));
++   return w;
++#else  //}{
++   return 0;
++#endif  //}
++}
++
++ULong arm_dirtyhelper_MRRS_CNTVCT ( void )
++{
++#if   __ARM_ARCH_ISA_ARM  //}{
++   UInt w0;
++   UInt w1;
++   __asm__ __volatile__("mrrc p15, 1, %0, %1, c14" : "=r"(w0), "=r"(w1));
++   return (((ULong)w1)<<32) | w0;
++#elif __ARM_ARCH_ISA_A64  //{
++   ULong w;
++   __asm__ __volatile__("mrs %0, cntvct_el0" : "=r"(w));
++   return w;
++#else  //}{
++   return 0;
++#endif  //}
++}
++
++ULong arm_dirtyhelper_MRRS_CNTPCT ( void )
++{
++#if   __ARM_ARCH_ISA_ARM  //}{
++   UInt w0;
++   UInt w1;
++   __asm__ __volatile__("mrrc p15, 0, %0, %1, c14" : "=r"(w0), "=r"(w1));
++   return (((ULong)w1)<<32) | w0;
++#elif __ARM_ARCH_ISA_A64  //{
++   ULong w;
++   __asm__ __volatile__("mrs %0, cntpct_el0" : "=r"(w));
++   return w;
++#else  //}{
++   return 0;
++#endif  //}
++}
++
+ /*---------------------------------------------------------------*/
+ /*--- end                                 guest_arm_helpers.c ---*/
+ /*---------------------------------------------------------------*/
+diff --git a/VEX/priv/guest_arm_toIR.c b/VEX/priv/guest_arm_toIR.c
+index d858c85e0..f96af92c4 100644
+--- a/VEX/priv/guest_arm_toIR.c
++++ b/VEX/priv/guest_arm_toIR.c
+@@ -18755,6 +18755,87 @@ DisResult disInstr_ARM_WRK (
+       /* fall through */
+    }
+ 
++   /* CNTFRQ: mrc p15, 0, rX, c14, c0, 0 */
++   if (0x0e1e0f10 == (insn & 0x0FFF0FFF)) {
++      UInt rD = INSN(15,12);
++      if (rD <= 14) {
++         /* skip r15, that's too stupid to handle */
++         IRTemp   val  = newTemp(Ity_I32);
++         IRExpr** args = mkIRExprVec_0();
++         IRDirty* d    = unsafeIRDirty_1_N(
++                            val,
++                            0/*regparms*/,
++                            "arm_dirtyhelper_MRS_CNTFRQ",
++                            &arm_dirtyhelper_MRS_CNTFRQ,
++                            args
++                         );
++         /* execute the dirty call, dumping the result in val. */
++         stmt( IRStmt_Dirty(d) );
++         putIRegA(rD, mkexpr(val), condT, Ijk_Boring);
++         DIP("mrc%s p15, 0, r%u, c14, c0, 0\n", nCC(INSN_COND), rD);
++         goto decode_success;
++      }
++      /* fall through */
++   }
++
++   /* CNTPCT */
++   if (0x0c500f0e == (insn & 0x0FF00FFF)) {
++      UInt rDhi = INSN(19,16);
++      UInt rDlo = INSN(15,12);
++      if (rDhi <= 14 && rDlo <= 14) {
++         /* skip r15, that's too stupid to handle */
++         IRTemp resHi  = newTemp(Ity_I32);
++         IRTemp resLo  = newTemp(Ity_I32);
++         IRTemp   val  = newTemp(Ity_I64);
++         IRExpr** args = mkIRExprVec_0();
++         IRDirty* d    = unsafeIRDirty_1_N(
++                            val,
++                            0/*regparms*/,
++                            "arm_dirtyhelper_MRRS_CNTPCT",
++                            &arm_dirtyhelper_MRRS_CNTPCT,
++                            args
++                         );
++         /* execute the dirty call, dumping the result in val. */
++         stmt( IRStmt_Dirty(d) );
++         assign( resHi, unop(Iop_64HIto32, mkexpr(val)) );
++         assign( resLo, unop(Iop_64to32, mkexpr(val)) );
++         putIRegA( rDhi, mkexpr(resHi), condT, Ijk_Boring );
++         putIRegA( rDlo, mkexpr(resLo), condT, Ijk_Boring );
++         DIP("mrrc%s p15, 0, r%u, r%u, c14\n", nCC(INSN_COND), rDlo, rDhi);
++         goto decode_success;
++      }
++      /* fall through */
++   }
++
++   /* CNTVCT */
++   if (0x0c500f1e == (insn & 0x0FF00FFF)) {
++      UInt rDhi = INSN(19,16);
++      UInt rDlo = INSN(15,12);
++      if (rDhi <= 14 && rDlo <= 14) {
++         /* skip r15, that's too stupid to handle */
++         IRTemp resHi  = newTemp(Ity_I32);
++         IRTemp resLo  = newTemp(Ity_I32);
++         IRTemp   val  = newTemp(Ity_I64);
++         IRExpr** args = mkIRExprVec_0();
++         IRDirty* d    = unsafeIRDirty_1_N(
++                            val,
++                            0/*regparms*/,
++                            "arm_dirtyhelper_MRRS_CNTVCT",
++                            &arm_dirtyhelper_MRRS_CNTVCT,
++                            args
++                         );
++         /* execute the dirty call, dumping the result in val. */
++         stmt( IRStmt_Dirty(d) );
++         assign( resHi, unop(Iop_64HIto32, mkexpr(val)) );
++         assign( resLo, unop(Iop_64to32, mkexpr(val)) );
++         putIRegA( rDhi, mkexpr(resHi), condT, Ijk_Boring );
++         putIRegA( rDlo, mkexpr(resLo), condT, Ijk_Boring );
++         DIP("mrrc%s p15, 1, r%u, r%u, c14\n", nCC(INSN_COND), rDlo, rDhi);
++         goto decode_success;
++      }
++      /* fall through */
++   }
++
+    /* Handle various kinds of barriers.  This is rather indiscriminate
+       in the sense that they are all turned into an IR Fence, which
+       means we don't know which they are, so the back end has to
+@@ -23196,6 +23277,84 @@ DisResult disInstr_THUMB_WRK (
+       /* fall through */
+    }
+ 
++   /* CNTFRQ: mrc p15, 0, rX, c14, c0, 0 */
++   if ((INSN0(15,0) == 0xee1e) && (INSN1(11,0) == 0xf10)) {
++      UInt rD = INSN1(15,12);
++      if (!isBadRegT(rD)) {
++         IRTemp   val  = newTemp(Ity_I32);
++         IRExpr** args = mkIRExprVec_0();
++         IRDirty* d    = unsafeIRDirty_1_N(
++                            val,
++                            0/*regparms*/,
++                            "arm_dirtyhelper_MRS_CNTFRQ",
++                            &arm_dirtyhelper_MRS_CNTFRQ,
++                            args
++                         );
++         /* execute the dirty call, dumping the result in val. */
++         stmt( IRStmt_Dirty(d) );
++         putIRegT(rD, mkexpr(val), condT);
++         DIP("mrc p15, 0, r%u, c14, c0, 0\n", rD);
++         goto decode_success;
++      }
++      /* fall through */
++   }
++
++   /* CNTPCT */
++   if ((INSN0(15,4) == 0xec5) && (INSN1(11,0) == 0xf0e)) {
++      UInt rDhi = INSN0(3,0);
++      UInt rDlo = INSN1(15,12);
++      if (!isBadRegT(rDhi) && !isBadRegT(rDlo)) {
++         IRTemp resHi  = newTemp(Ity_I32);
++         IRTemp resLo  = newTemp(Ity_I32);
++         IRTemp   val  = newTemp(Ity_I64);
++         IRExpr** args = mkIRExprVec_0();
++         IRDirty* d    = unsafeIRDirty_1_N(
++                            val,
++                            0/*regparms*/,
++                            "arm_dirtyhelper_MRRS_CNTPCT",
++                            &arm_dirtyhelper_MRRS_CNTPCT,
++                            args
++                         );
++         /* execute the dirty call, dumping the result in val. */
++         stmt( IRStmt_Dirty(d) );
++         assign( resHi, unop(Iop_64HIto32, mkexpr(val)) );
++         assign( resLo, unop(Iop_64to32, mkexpr(val)) );
++         putIRegT( rDhi, mkexpr(resHi), condT );
++         putIRegT( rDlo, mkexpr(resLo), condT );
++         DIP("mrrc p15, 0, r%u, r%u, c14\n", rDlo, rDhi);
++         goto decode_success;
++      }
++      /* fall through */
++   }
++
++   /* CNTVCT */
++   if ((INSN0(15,4) == 0xec5) && (INSN1(11,0) == 0xf1e)) {
++      UInt rDhi = INSN0(3,0);
++      UInt rDlo = INSN1(15,12);
++      if (!isBadRegT(rDhi) && !isBadRegT(rDlo)) {
++         IRTemp resHi  = newTemp(Ity_I32);
++         IRTemp resLo  = newTemp(Ity_I32);
++         IRTemp   val  = newTemp(Ity_I64);
++         IRExpr** args = mkIRExprVec_0();
++         IRDirty* d    = unsafeIRDirty_1_N(
++                            val,
++                            0/*regparms*/,
++                            "arm_dirtyhelper_MRRS_CNTVCT",
++                            &arm_dirtyhelper_MRRS_CNTVCT,
++                            args
++                         );
++         /* execute the dirty call, dumping the result in val. */
++         stmt( IRStmt_Dirty(d) );
++         assign( resHi, unop(Iop_64HIto32, mkexpr(val)) );
++         assign( resLo, unop(Iop_64to32, mkexpr(val)) );
++         putIRegT( rDhi, mkexpr(resHi), condT );
++         putIRegT( rDlo, mkexpr(resLo), condT );
++         DIP("mrrc p15, 1, r%u, r%u, c14\n", rDlo, rDhi);
++         goto decode_success;
++      }
++      /* fall through */
++   }
++
+    /* ------------------- CLREX ------------------ */
+    if (INSN0(15,0) == 0xF3BF && INSN1(15,0) == 0x8F2F) {
+       /* AFAICS, this simply cancels a (all?) reservations made by a

--- a/recipes-devtools/valgrind/valgrind_%.bbappend
+++ b/recipes-devtools/valgrind/valgrind_%.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+# from https://bugs.kde.org/show_bug.cgi?id=344802 (John Reiser)
+SRC_URI += "file://bug344802-unhandled-0xec510f1e.patch"

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -71,8 +71,11 @@ do_install_ptest() {
     cp -r ${B}/ ${D}/${PTEST_PATH}/build
     cp -r ${S}/ ${D}/${PTEST_PATH}/src
 
-    # remove bogus elf file
-    rm ${D}/${PTEST_PATH}/src/partial/extern/RIOT/cpu/esp32/bin/bootloader.elf
+    # remove huge external unused repository
+    rm -rf ${D}/${PTEST_PATH}/src/partial/extern/RIOT
+
+    # remove huge build artifacts
+    find ${D}/${PTEST_PATH}/build/src -name "*.a" -delete
 
     # fix the absolute paths
     find ${D}/${PTEST_PATH}/build -name "CMakeFiles" | xargs rm -rf

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -28,7 +28,7 @@ SRC_URI = " \
 SRC_URI[md5sum] = "30d7f0931e2236954679e75d1bae174f"
 SRC_URI[sha256sum] = "46d8c6448ce14cbb9af6a93eba7e29d38579e566dcd6518d22f723a8da16cad5"
 
-SRCREV = "ea03a5cf57def6b8d368f783cb12b91255365a80"
+SRCREV = "2e3ccbbdd43fdf70eb815454ea64f0bd8085856c"
 BRANCH ?= "master"
 
 S = "${WORKDIR}/git"

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -39,6 +39,10 @@ S = "${WORKDIR}/git"
 
 inherit cmake pkgconfig ptest systemd
 
+# disable ptest by default as it slows down builds quite a lot
+# can be enabled manually by setting 'PTEST_ENABLED_pn-aktualizr' to '1' in local.conf
+PTEST_ENABLED = "0"
+
 SYSTEMD_PACKAGES = "${PN} ${PN}-secondary"
 SYSTEMD_SERVICE_${PN} = "aktualizr.service"
 SYSTEMD_SERVICE_${PN}-secondary = "aktualizr-secondary.socket"

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -6,6 +6,7 @@ LICENSE = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=9741c346eef56131163e13b9db1241b3"
 
 DEPENDS = "boost curl openssl libarchive libsodium sqlite3 asn1c-native"
+DEPENDS_append = "${@bb.utils.contains('PTEST_ENABLED', '1', ' coreutils-native ostree-native aktualizr-native ', '', d)}"
 RDEPENDS_${PN}_class-target = "aktualizr-check-discovery aktualizr-configs lshw"
 RDEPENDS_${PN}-secondary = "aktualizr-check-discovery"
 RDEPENDS_${PN}-host-tools = "aktualizr aktualizr-repo aktualizr-cert-provider ${@bb.utils.contains('PACKAGECONFIG', 'sota-tools', 'garage-deploy garage-push', '', d)}"
@@ -33,7 +34,7 @@ BRANCH ?= "master"
 
 S = "${WORKDIR}/git"
 
-inherit pkgconfig cmake systemd
+inherit cmake pkgconfig ptest systemd
 
 SYSTEMD_PACKAGES = "${PN} ${PN}-secondary"
 SYSTEMD_SERVICE_${PN} = "aktualizr.service"
@@ -53,6 +54,10 @@ PACKAGECONFIG[systemd] = "-DBUILD_SYSTEMD=ON,-DBUILD_SYSTEMD=OFF,systemd,"
 PACKAGECONFIG[load-tests] = "-DBUILD_LOAD_TESTS=ON,-DBUILD_LOAD_TESTS=OFF,"
 PACKAGECONFIG[serialcan] = ",,,slcand-start"
 PACKAGECONFIG[ubootenv] = ",,,u-boot-fw-utils aktualizr-uboot-env-rollback"
+
+do_compile_ptest() {
+    cmake_runcmake_build --target build_tests
+}
 
 do_install_append () {
     install -d ${D}${libdir}/sota

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -11,7 +11,7 @@ RDEPENDS_${PN}_class-target = "aktualizr-check-discovery aktualizr-configs lshw"
 RDEPENDS_${PN}-secondary = "aktualizr-check-discovery"
 RDEPENDS_${PN}-host-tools = "aktualizr aktualizr-repo aktualizr-cert-provider ${@bb.utils.contains('PACKAGECONFIG', 'sota-tools', 'garage-deploy garage-push', '', d)}"
 
-RDEPENDS_${PN}-ptest += "bash cmake python3-core python3-io python3-json python3-netserver sqlite3 valgrind"
+RDEPENDS_${PN}-ptest += "bash cmake curl python3-modules sqlite3 valgrind"
 
 PV = "1.0+git${SRCPV}"
 PR = "7"

--- a/recipes-sota/aktualizr/files/run-ptest
+++ b/recipes-sota/aktualizr/files/run-ptest
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+
+filter_logs() {
+    awk '/^.*Test[[:space:]]*#[[:digit:]]+:/ {
+        a = gensub(/^.*Test[[:space:]]*#[[:digit:]]+:[[:space:]]*([^[:space:]]+).*(Passed|Skipped|Not Run|Failed|Timeout|Exception)[[:space:]:].*$/, "\\2: \\1", "g");
+        a = gensub(/^Passed/, "PASS", "g", a);
+        a = gensub(/^(Skipped|Disabled)/, "SKIP", "g", a);
+        a = gensub(/^(Not Run|Failed|Timeout|Exception)/, "FAIL", "g", a);
+        print a;
+    }'
+}
+
+cd build
+ctest -j 8 -O /tmp/aktualizr-ptest.log --output-on-failure -LE 'noptest' 2> /dev/null | filter_logs


### PR DESCRIPTION
The needed CMake trickery is actually quite small!
But it copies the whole build and source directories on the device, which causes some rather long build times.

Tests are run under valgrind, with regular release compilation flags.

To run:
- ~~use these changes: https://github.com/advancedtelematic/aktualizr/pull/1119~~
- add `aktualizr-ptest` and `ptest-runner` in `IMAGE_INSTALL_append`
- (edit) also add `PTEST_ENABLED_pn-aktualizr = "1"` to the bitbake configuration
- build an image
- run `ptest-runner` on the device

On my last run under qemu, the only error was:

```
[ RUN      ] fetcher.test_pause_ostree
created: /tmp/aktualizr-7819-b833-8d28-c0e1/dd1f-9831-dir
Bootstraping DB to version 18
...
Fetcher: nothing to pause
Fetcher: nothing to resume
Fetcher: already paused
client_pkey not present in db
client_cert not present in db
ca_cert not present
Fetcher: nothing to resume
ostree-pull: Receiving metadata objects: 1 outstanding: 1
progress callback: 0
ostree-pull: Writing objects: 1
ostree-pull: Writing objects: 1
Error while pulling image: Writing content object: fsetxattr(user.ostreemeta): Operation not supported
Downloaded 100MB in 8seconds
/usr/src/debug/aktualizr/1.0+gitAUTOINC+bd4318b562-7/git/src/libaktualizr/uptane/fetcher_test.cc:97: Failure
Value of: result.get()
  Actual: false
Expected: true
[  FAILED  ] fetcher.test_pause_ostree (13356 ms)
```

Coincidentally, I have the same problem on my local environment for some weeks now.

Would be curious to try on a raspberrypi as well!


I also had a problem with boost and dynamic linking at some point which got fixed by downgrading yocto's boost recipe. I'll try to dig a bit more into that, it might have been a transient issue that required a fresh rebuild of some recipes. 