### PR TITLE
aktualizr: Use ${libdir_native} when referring to native files

### DIFF
--- a/recipes-sota/aktualizr/aktualizr-auto-prov.bb
+++ b/recipes-sota/aktualizr/aktualizr-auto-prov.bb
@@ -31,7 +31,7 @@ do_install() {
     install -m 0700 -d ${D}${libdir}/sota/conf.d
     aktualizr_toml=${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'secondary-network', 'sota_autoprov_primary.toml', 'sota_autoprov.toml', d)}
 
-    install -m 0644 ${STAGING_DIR_NATIVE}${libdir}/sota/${aktualizr_toml} \
+    install -m 0644 ${STAGING_DIR_NATIVE}${libdir_native}/sota/${aktualizr_toml} \
         ${D}${libdir}/sota/conf.d/20-${aktualizr_toml}
 }
 

--- a/recipes-sota/aktualizr/aktualizr-hsm-prov.bb
+++ b/recipes-sota/aktualizr/aktualizr-hsm-prov.bb
@@ -16,7 +16,7 @@ require credentials.inc
 
 do_install() {
     install -m 0700 -d ${D}${libdir}/sota/conf.d
-    install -m 0644 ${STAGING_DIR_NATIVE}${libdir}/sota/sota_hsm_prov.toml \
+    install -m 0644 ${STAGING_DIR_NATIVE}${libdir_native}/sota/sota_hsm_prov.toml \
         ${D}${libdir}/sota/conf.d/20-sota_hsm_prov.toml
 }
 

--- a/recipes-sota/aktualizr/aktualizr-uboot-env-rollback.bb
+++ b/recipes-sota/aktualizr/aktualizr-uboot-env-rollback.bb
@@ -8,7 +8,7 @@ RDEPENDS_${PN} = "aktualizr"
 
 do_install() {
     install -m 0700 -d ${D}${libdir}/sota/conf.d
-    install -m 0644 ${STAGING_DIR_NATIVE}${libdir}/sota/sota_uboot_env.toml ${D}${libdir}/sota/conf.d/30-rollback.toml
+    install -m 0644 ${STAGING_DIR_NATIVE}${libdir_native}/sota/sota_uboot_env.toml ${D}${libdir}/sota/conf.d/30-rollback.toml
 }
 
 FILES_${PN} = " \

--- a/recipes-sota/ostree/ostree_git.bb
+++ b/recipes-sota/ostree/ostree_git.bb
@@ -57,13 +57,13 @@ FILES_${PN} = "${bindir} \
     ${sysconfdir}/ostree \
     ${datadir}/ostree \
     ${libdir}/*.so.* \
-    ${libdir}/ostree/ostree-grub-generator \
-    ${libdir}/ostree/ostree-remount \
+    /usr/lib/ostree/ostree-grub-generator \
+    /usr/lib/ostree/ostree-remount \
     ${libdir}/girepository-1.0/* \
-    ${@bb.utils.contains('DISTRO_FEATURES','systemd','${libdir}/tmpfiles.d', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES','systemd','/usr/lib/tmpfiles.d', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES','systemd','${systemd_unitdir}/system/*.path', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES','systemd','${systemd_unitdir}/system-generators', '', d)} \
 "
 FILES_${PN}-dev += " ${datadir}/gir-1.0"
-FILES_${PN}-dracut = "${sysconfdir}/dracut.conf.d ${libdir}/dracut"
-FILES_${PN}-switchroot = "${libdir}/ostree/ostree-prepare-root"
+FILES_${PN}-dracut = "${sysconfdir}/dracut.conf.d /usr/lib/dracut"
+FILES_${PN}-switchroot = "/usr/lib/ostree/ostree-prepare-root"


### PR DESCRIPTION
Several recipes had ${STAGING_DIR_NATIVE}${libdir}, which won't
work if ${libdir} != ${libdir_native}.

Signed-off-by: Corey Minyard <cminyard@mvista.com>