### PR TITLE
fit-conf: se PACKAGE_ARCH to ${MACHINE_ARCH}

### DIFF
--- a/recipes-sota/fit-conf/fit-conf.bb
+++ b/recipes-sota/fit-conf/fit-conf.bb
@@ -2,6 +2,8 @@ SUMMARY = "FIT image configuration for u-boot to use"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
 do_install() {
 	mkdir -p ${D}${libdir}
 	echo -n "fit_conf=" >${D}${libdir}/fit_conf


### PR DESCRIPTION
fit-conf should be a machine specific package instead of being a arch
specific package.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>