### PR TITLE
Remove connman

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -74,6 +74,8 @@ You may take a look into https://github.com/advancedtelematic/meta-updater-minno
 
 Although we have used U-Boot so far, other boot loaders can be configured work with OSTree as well.
 
+Your images will also need network connectivity to be able to reach an actual OTA backend. Our 'poky-sota' distribution does not mandate or install a default network manager but our supported platforms use the `virtual/network-configuration` recipe, which can be used as a starting example.
+
 == SOTA-related variables in local.conf
 
 * `OSTREE_REPO` - path to your OSTree repository. Defaults to `$\{DEPLOY_DIR_IMAGE}/ostree_repo`

--- a/classes/sota_am335x-evm-wifi.bbclass
+++ b/classes/sota_am335x-evm-wifi.bbclass
@@ -7,7 +7,6 @@ IMAGE_BOOT_FILES_sota = "bootfiles/*"
 OSTREE_KERNEL_ARGS ?= "ramdisk_size=16384 root=/dev/ram0 rw rootfstype=ext4 rootwait rootdelay=2 ostree_root=/dev/mmcblk0p2 console=ttyO0,115200n8l"
 
 IMAGE_INSTALL_append_sota = " uim iw wl18xx-calibrator wlconf wl18xx-fw hostapd wpa-supplicant"
-IMAGE_INSTALL_remove_sota = " connman connman-client"
 
 PREFERRED_VERSION_linux-ti-staging_sota = "4.4.54+gitAUTOINC+ecd4eada6f"
 

--- a/classes/sota_m3ulcb.bbclass
+++ b/classes/sota_m3ulcb.bbclass
@@ -6,3 +6,5 @@ IMAGE_BOOT_FILES_sota += "m3ulcb-ota-bootfiles/*"
 
 OSTREE_BOOTLOADER ?= "u-boot"
 UBOOT_MACHINE_sota = "m3ulcb_defconfig"
+
+IMAGE_INSTALL_append_sota = " connman connman-client"

--- a/classes/sota_m3ulcb.bbclass
+++ b/classes/sota_m3ulcb.bbclass
@@ -7,4 +7,5 @@ IMAGE_BOOT_FILES_sota += "m3ulcb-ota-bootfiles/*"
 OSTREE_BOOTLOADER ?= "u-boot"
 UBOOT_MACHINE_sota = "m3ulcb_defconfig"
 
-IMAGE_INSTALL_append_sota = " connman connman-client"
+PREFERRED_RPROVIDER_virtual/network-configuration ?= "connman"
+IMAGE_INSTALL_append_sota = " virtual/network-configuration "

--- a/classes/sota_minnowboard.bbclass
+++ b/classes/sota_minnowboard.bbclass
@@ -7,4 +7,5 @@ IMAGE_BOOT_FILES_sota = ""
 IMAGE_FSTYPES_remove_sota = "live hddimg"
 OSTREE_KERNEL_ARGS ?= "ramdisk_size=16384 rw rootfstype=ext4 rootwait rootdelay=2 console=ttyS0,115200 console=tty0"
 
+IMAGE_INSTALL_append_sota = " connman connman-client"
 IMAGE_INSTALL_append = " minnowboard-efi-startup"

--- a/classes/sota_minnowboard.bbclass
+++ b/classes/sota_minnowboard.bbclass
@@ -6,6 +6,7 @@ IMAGE_BOOT_FILES_sota = ""
 
 IMAGE_FSTYPES_remove_sota = "live hddimg"
 OSTREE_KERNEL_ARGS ?= "ramdisk_size=16384 rw rootfstype=ext4 rootwait rootdelay=2 console=ttyS0,115200 console=tty0"
-
-IMAGE_INSTALL_append_sota = " connman connman-client"
 IMAGE_INSTALL_append = " minnowboard-efi-startup"
+
+PREFERRED_RPROVIDER_virtual/network-configuration ?= "connman"
+IMAGE_INSTALL_append_sota = " virtual/network-configuration "

--- a/classes/sota_porter.bbclass
+++ b/classes/sota_porter.bbclass
@@ -7,3 +7,4 @@ IMAGE_BOOT_FILES_sota += "porter-bootfiles/*"
 OSTREE_BOOTLOADER ?= "u-boot"
 UBOOT_MACHINE_sota = "porter_config"
 
+IMAGE_INSTALL_append_sota = " connman connman-client"

--- a/classes/sota_porter.bbclass
+++ b/classes/sota_porter.bbclass
@@ -7,4 +7,5 @@ IMAGE_BOOT_FILES_sota += "porter-bootfiles/*"
 OSTREE_BOOTLOADER ?= "u-boot"
 UBOOT_MACHINE_sota = "porter_config"
 
-IMAGE_INSTALL_append_sota = " connman connman-client"
+PREFERRED_RPROVIDER_virtual/network-configuration ?= "connman"
+IMAGE_INSTALL_append_sota = " virtual/network-configuration "

--- a/classes/sota_qemux86-64.bbclass
+++ b/classes/sota_qemux86-64.bbclass
@@ -12,3 +12,5 @@ IMAGE_ROOTFS_EXTRA_SPACE = "${@bb.utils.contains('DISTRO_FEATURES', 'sota', '655
 
 # fix for u-boot/swig build issue
 HOSTTOOLS_NONFATAL += "x86_64-linux-gnu-gcc"
+
+IMAGE_INSTALL_append_sota = " connman connman-client"

--- a/classes/sota_qemux86-64.bbclass
+++ b/classes/sota_qemux86-64.bbclass
@@ -13,4 +13,4 @@ IMAGE_ROOTFS_EXTRA_SPACE = "${@bb.utils.contains('DISTRO_FEATURES', 'sota', '655
 # fix for u-boot/swig build issue
 HOSTTOOLS_NONFATAL += "x86_64-linux-gnu-gcc"
 
-IMAGE_INSTALL_append_sota = " connman connman-client"
+IMAGE_INSTALL_append_sota = " ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'networkd-dhcp-conf', '', d)} "

--- a/classes/sota_qemux86-64.bbclass
+++ b/classes/sota_qemux86-64.bbclass
@@ -13,4 +13,4 @@ IMAGE_ROOTFS_EXTRA_SPACE = "${@bb.utils.contains('DISTRO_FEATURES', 'sota', '655
 # fix for u-boot/swig build issue
 HOSTTOOLS_NONFATAL += "x86_64-linux-gnu-gcc"
 
-IMAGE_INSTALL_append_sota = " ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'networkd-dhcp-conf', '', d)} "
+IMAGE_INSTALL_append_sota = " virtual/network-configuration "

--- a/classes/sota_raspberrypi.bbclass
+++ b/classes/sota_raspberrypi.bbclass
@@ -11,6 +11,7 @@ UBOOT_DTBO_LOADADDRESS = "0x06000000"
 
 # Deploy config fragment list to OSTree root fs
 IMAGE_INSTALL_append = " fit-conf"
+IMAGE_INSTALL_append_sota = " connman connman-client"
 
 PREFERRED_PROVIDER_virtual/bootloader_sota ?= "u-boot"
 UBOOT_ENTRYPOINT_sota ?= "0x00008000"
@@ -34,4 +35,3 @@ SOTA_DT_OVERLAYS_raspberrypi3 ?= "vc4-kms-v3d.dtbo rpi-ft5406.dtbo"
 OSTREE_KERNEL_ARGS_sota ?= " 8250.nr_uarts=1 bcm2708_fb.fbwidth=656 bcm2708_fb.fbheight=614 bcm2708_fb.fbswap=1 vc_mem.mem_base=0x3ec00000 vc_mem.mem_size=0x40000000 dwc_otg.lpm_enable=0 console=ttyS0,115200 usbhid.mousepoll=0 "
 
 SOTA_CLIENT_FEATURES_append = " ubootenv"
-

--- a/classes/sota_raspberrypi.bbclass
+++ b/classes/sota_raspberrypi.bbclass
@@ -11,7 +11,9 @@ UBOOT_DTBO_LOADADDRESS = "0x06000000"
 
 # Deploy config fragment list to OSTree root fs
 IMAGE_INSTALL_append = " fit-conf"
-IMAGE_INSTALL_append_sota = " connman connman-client"
+
+PREFERRED_RPROVIDER_virtual/network-configuration ?= "connman"
+IMAGE_INSTALL_append_sota = " virtual/network-configuration "
 
 PREFERRED_PROVIDER_virtual/bootloader_sota ?= "u-boot"
 UBOOT_ENTRYPOINT_sota ?= "0x00008000"

--- a/classes/sota_raspberrypi.bbclass
+++ b/classes/sota_raspberrypi.bbclass
@@ -12,7 +12,7 @@ UBOOT_DTBO_LOADADDRESS = "0x06000000"
 # Deploy config fragment list to OSTree root fs
 IMAGE_INSTALL_append = " fit-conf"
 
-PREFERRED_RPROVIDER_virtual/network-configuration ?= "connman"
+DEV_MATCH_DIRECTIVE_pn-networkd-dhcp-conf = "Driver=smsc95xx lan78xx"
 IMAGE_INSTALL_append_sota = " virtual/network-configuration "
 
 PREFERRED_PROVIDER_virtual/bootloader_sota ?= "u-boot"

--- a/conf/distro/poky-sota-systemd.conf
+++ b/conf/distro/poky-sota-systemd.conf
@@ -9,5 +9,3 @@ DISTRO_CODENAME = "sota"
 
 DISTRO_FEATURES_append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"
-
-IMAGE_INSTALL_append = " connman connman-client"

--- a/conf/distro/poky-sota-systemd.conf
+++ b/conf/distro/poky-sota-systemd.conf
@@ -9,3 +9,4 @@ DISTRO_CODENAME = "sota"
 
 DISTRO_FEATURES_append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"
+PREFERRED_RPROVIDER_virtual/network-configuration ??= "networkd-dhcp-conf"

--- a/conf/distro/poky-sota.conf
+++ b/conf/distro/poky-sota.conf
@@ -5,5 +5,3 @@ DISTRO = "poky-sota"
 DISTRO_NAME = "OTA-enabled Linux"
 DISTRO_VERSION = "1.0"
 DISTRO_CODENAME = "sota"
-
-IMAGE_INSTALL_append = " connman connman-client"

--- a/recipes-connectivity/connman/connman_%.bbappend
+++ b/recipes-connectivity/connman/connman_%.bbappend
@@ -1,0 +1,1 @@
+RPROVIDES_${PN} += "virtual/network-configuration"

--- a/recipes-connectivity/networkd-dhcp-conf/files/20-wired-dhcp.network
+++ b/recipes-connectivity/networkd-dhcp-conf/files/20-wired-dhcp.network
@@ -1,0 +1,5 @@
+[Match]
+Name=en*
+
+[Network]
+DHCP=yes

--- a/recipes-connectivity/networkd-dhcp-conf/files/20-wired-dhcp.network
+++ b/recipes-connectivity/networkd-dhcp-conf/files/20-wired-dhcp.network
@@ -1,5 +1,5 @@
 [Match]
-Name=en*
+@MATCH_DIRECTIVE@
 
 [Network]
 DHCP=yes

--- a/recipes-connectivity/networkd-dhcp-conf/networkd-dhcp-conf.bb
+++ b/recipes-connectivity/networkd-dhcp-conf/networkd-dhcp-conf.bb
@@ -1,0 +1,23 @@
+SUMMARY = "systemd-networkd config to setup wired interface with dhcp"
+DESCRIPTION = "Provides automatic dhcp network configuration for wired \
+interfaces through systemd-networkd"
+LICENSE = "MPL-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
+
+inherit systemd
+
+SRC_URI_append = " file://20-wired-dhcp.network"
+PR = "r1"
+
+RDEPENDS_${PN} = "systemd"
+
+S = "${WORKDIR}"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+FILES_${PN} = "${systemd_unitdir}/network/*"
+
+do_install() {
+    install -d ${D}/${systemd_unitdir}/network
+    install -m 0644 ${WORKDIR}/20-wired-dhcp.network ${D}/${systemd_unitdir}/network
+}

--- a/recipes-connectivity/networkd-dhcp-conf/networkd-dhcp-conf.bb
+++ b/recipes-connectivity/networkd-dhcp-conf/networkd-dhcp-conf.bb
@@ -19,7 +19,10 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 FILES_${PN} = "${systemd_unitdir}/network/*"
 
+DEV_MATCH_DIRECTIVE ?= "Name=en*"
+
 do_install() {
     install -d ${D}/${systemd_unitdir}/network
     install -m 0644 ${WORKDIR}/20-wired-dhcp.network ${D}/${systemd_unitdir}/network
+    sed -i -e 's|@MATCH_DIRECTIVE@|${DEV_MATCH_DIRECTIVE}|g' ${D}${systemd_unitdir}/network/20-wired-dhcp.network
 }

--- a/recipes-connectivity/networkd-dhcp-conf/networkd-dhcp-conf.bb
+++ b/recipes-connectivity/networkd-dhcp-conf/networkd-dhcp-conf.bb
@@ -6,6 +6,8 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7
 
 inherit systemd
 
+RPROVIDES_${PN} = "virtual/network-configuration"
+
 SRC_URI_append = " file://20-wired-dhcp.network"
 PR = "r1"
 

--- a/recipes-test/images/secondary-image.bb
+++ b/recipes-test/images/secondary-image.bb
@@ -17,6 +17,7 @@ IMAGE_INSTALL_remove = " \
                         aktualizr-uboot-env-rollback \
                         connman \
                         connman-client \
+                        networkd-dhcp-conf \
                         "
 
 IMAGE_INSTALL_append = " \

--- a/recipes-test/images/secondary-image.bb
+++ b/recipes-test/images/secondary-image.bb
@@ -15,9 +15,7 @@ IMAGE_INSTALL_remove = " \
                         aktualizr-ca-implicit-prov-creds \
                         aktualizr-hsm-prov \
                         aktualizr-uboot-env-rollback \
-                        connman \
-                        connman-client \
-                        networkd-dhcp-conf \
+                        virtual/network-configuration \
                         "
 
 IMAGE_INSTALL_append = " \


### PR DESCRIPTION
connman is an annoying dependency which is not present in the base poky distribution.

The first step is to remove it from default poky-sota.conf and add it back on the various machines that we have.

The second step is to replace it with a simple systemd-networkd configuration on qemux86-64. We can migrate other platforms later.

One notable change is that users of the layer without systemd won't have a default network configuration on qemux86-64 but:

* we don't test anything without systemd
* users are expected to know better about their network configuration requirements than us

One even less intrusive alternative would be to add the `IMAGE_INSTALL_append` in the default local.conf generated by envsetup.sh. But since I wanted to do it on a per-machine basis for now, it requires a bit more changes.

**oe-selftest ongoing, I'll try to push the changes for raspberrypi as well if everything works fine**