### PR TITLE
OTA-2418: Remove example.com URL from automated garage-sign usage

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -212,6 +212,11 @@ IMAGE_CMD_garagesign () {
         # Push may fail due to race condition when multiple build machines try to push simultaneously
         #   in which case targets.json should be pulled again and the whole procedure repeated
         push_success=0
+	target_url=""
+	if [ -n "${GARAGE_TARGET_URL}" ]; then
+		target_url='--url ${GARAGE_TARGET_URL}'
+	fi
+
         for push_retries in $( seq 3 ); do
             garage-sign targets pull --repo tufrepo \
                                      --home-dir ${GARAGE_SIGN_REPO}
@@ -221,7 +226,7 @@ IMAGE_CMD_garagesign () {
                                     --format OSTREE \
                                     --version ${target_version} \
                                     --length 0 \
-                                    --url "${GARAGE_TARGET_URL}" \
+                                    ${target_url} \
                                     --sha256 ${ostree_target_hash} \
                                     --hardwareids ${SOTA_HARDWARE_ID}
             garage-sign targets sign --repo tufrepo \

--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -36,7 +36,7 @@ GARAGE_SIGN_REPO ?= "${DEPLOY_DIR_IMAGE}/garage_sign_repo"
 GARAGE_SIGN_KEYNAME ?= "garage-key"
 GARAGE_TARGET_NAME ?= "${OSTREE_BRANCHNAME}"
 GARAGE_TARGET_VERSION ?= ""
-GARAGE_TARGET_URL ?= "https://example.com/"
+GARAGE_TARGET_URL ?= ""
 
 SOTA_MACHINE ??="none"
 SOTA_MACHINE_rpi ?= "raspberrypi"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_sota = "^${LAYERDIR}/"
 BBFILE_PRIORITY_sota = "7"
 
 LAYERDEPENDS_sota = "filesystems-layer"
-LAYERSERIES_COMPAT_sota = "thud"
+LAYERSERIES_COMPAT_sota = "thud warrior"


### PR DESCRIPTION
Signed-off-by: Mykhaylo Sul <ext-mykhaylo.sul@here.com>

Remove "https://example.com/" as a default value of GARAGE_TARGET_URL.
Bitbaked against https://github.com/advancedtelematic/aktualizr/tree/feat/OTA-2418/remove-example.com branch and tested 'happy path' (device registration and new updates installation) for two cases 

1. default value of GARAGE_TARGET_URL, which is ""
2. GARAGE_TARGET_URL set to "https://example.com/" in local.conf