### PR TITLE
Fix non-sota build issue in rocko

### DIFF
--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -23,8 +23,6 @@ WKS_FILE_sota ?= "sdimage-sota.wks"
 
 EXTRA_IMAGEDEPENDS_append_sota = " parted-native mtools-native dosfstools-native"
 
-OSTREE_INITRAMFS_FSTYPES ??= "${@oe.utils.ifelse(d.getVar('OSTREE_BOOTLOADER', True) == 'u-boot', 'ext4.gz.u-boot', 'ext4.gz')}"
-
 # Please redefine OSTREE_REPO in order to have a persistent OSTree repo
 export OSTREE_REPO ?= "${DEPLOY_DIR_IMAGE}/ostree_repo"
 export OSTREE_BRANCHNAME ?= "${SOTA_HARDWARE_ID}"

--- a/recipes-core/images/initramfs-ostree-image.bb
+++ b/recipes-core/images/initramfs-ostree-image.bb
@@ -13,6 +13,8 @@ IMAGE_LINGUAS = ""
 
 LICENSE = "MIT"
 
+OSTREE_INITRAMFS_FSTYPES ??= "${@oe.utils.ifelse(d.getVar('OSTREE_BOOTLOADER', True) == 'u-boot', 'ext4.gz.u-boot', 'ext4.gz')}"
+
 IMAGE_FSTYPES = "${OSTREE_INITRAMFS_FSTYPES}"
 
 inherit core-image


### PR DESCRIPTION
Well, I guess testing non-sota builds is not something that's done very much :-).  You get an error when you do this.  This patch seems to fix the issue, though I'm not 100% sure it's the right fix.