### PR TITLE
More robust aktualizr-ptest printing of errors

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -228,7 +228,7 @@ sudo apt install ovmf
 5. Run oe-selftest:
 +
 ```
-oe-selftest -r updater_native updater_qemux86_64 updater_minnowboard updater_raspberrypi
+oe-selftest -r updater_native updater_qemux86_64 updater_minnowboard updater_raspberrypi updater_qemux86_64_ptest
 ```
 
 For more information about oe-selftest, including details about how to run individual test modules or classes, please refer to the https://wiki.yoctoproject.org/wiki/Oe-selftest[Yocto Project wiki].

--- a/lib/oeqa/selftest/cases/updater_qemux86_64_ptest.py
+++ b/lib/oeqa/selftest/cases/updater_qemux86_64_ptest.py
@@ -41,12 +41,12 @@ class PtestTests(OESelftestTestCase):
         stdout, stderr, retcode = self.qemu_command('sh -l -c ptest-runner', timeout=None)
         output = stdout.decode()
         print(output)
-        self.assertEqual(retcode, 0)
 
         has_failure = re.search('^FAIL', output, flags=re.MULTILINE) is not None
         if has_failure:
             print("Full test suite log:")
-            stdout, stderr, retcode = self.qemu_command('cat /tmp/aktualizr-ptest.log', timeout=None)
+            stdout, _, _ = self.qemu_command('sh -c "cat /tmp/aktualizr-ptest.log || cat /tmp/aktualizr-ptest.log.tmp"', timeout=None)
             print(stdout.decode())
 
+        self.assertEqual(retcode, 0)
         self.assertFalse(has_failure)


### PR DESCRIPTION
If ctest is interrupted (e.g. timeout), its partial output will be in /tmp/aktualizr-ptest.log.tmp