### PR TITLE
Make aktualizr-ptest depend on python3-misc

### DIFF
--- a/lib/oeqa/selftest/cases/updater_qemux86_64_ptest.py
+++ b/lib/oeqa/selftest/cases/updater_qemux86_64_ptest.py
@@ -45,7 +45,7 @@ class PtestTests(OESelftestTestCase):
         has_failure = re.search('^FAIL', output, flags=re.MULTILINE) is not None
         if has_failure:
             print("Full test suite log:")
-            stdout, _, _ = self.qemu_command('sh -c "cat /tmp/aktualizr-ptest.log || cat /tmp/aktualizr-ptest.log.tmp"', timeout=None)
+            stdout, _, _ = self.qemu_command('cat /tmp/aktualizr-ptest.log || cat /tmp/aktualizr-ptest.log.tmp', timeout=None)
             print(stdout.decode())
 
         self.assertEqual(retcode, 0)

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -10,7 +10,7 @@ DEPENDS_append = "${@bb.utils.contains('PTEST_ENABLED', '1', ' coreutils-native 
 RDEPENDS_${PN}_class-target = "aktualizr-configs lshw"
 RDEPENDS_${PN}-host-tools = "aktualizr aktualizr-repo aktualizr-cert-provider ${@bb.utils.contains('PACKAGECONFIG', 'sota-tools', 'garage-deploy garage-push', '', d)}"
 
-RDEPENDS_${PN}-ptest += "bash cmake curl python3-modules openssl-bin sqlite3 valgrind"
+RDEPENDS_${PN}-ptest += "bash cmake curl python3-misc python3-modules openssl-bin sqlite3 valgrind"
 
 PV = "1.0+git${SRCPV}"
 PR = "7"


### PR DESCRIPTION
Some of our tests use pathlib which ends up in there...

Seems to be a problem on sumo at least, don't know how we haven't noticed on master... Still running tests to confirm!