### PR TITLE
aktualizr-polling-interval: new config fragment.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -96,6 +96,7 @@ Your images will also need network connectivity to be able to reach an actual OT
 * `SOTA_DT_OVERLAYS` - whitespace-separated list of used device tree overlays for FIT image. This list is OSTree-updateable as well.
 * `SOTA_EXTRA_CONF_FRAGS` - extra https://lxr.missinglinkelectronics.com/uboot/doc/uImage.FIT/overlay-fdt-boot.txt[configuration fragments] for FIT image.
 * `RESOURCE_xxx_pn-aktualizr` - controls maximum resource usage of the aktualizr service, when `aktualizr-resource-control` is installed on the image. See <<aktualizr service resource control>> for details.
+* `SOTA_POLLING_SEC` - sets polling interval for aktualizr to check for updates if aktualizr-polling-sec is included in the image.
 
 == Usage
 

--- a/recipes-sota/config/aktualizr-polling-interval.bb
+++ b/recipes-sota/config/aktualizr-polling-interval.bb
@@ -1,0 +1,29 @@
+SUMMARY = "Set polling interval in Aktualizr"
+DESCRIPTION = "Configures aktualizr to poll at a custom frequency (suitable for testing or other purposes)"
+HOMEPAGE = "https://github.com/advancedtelematic/aktualizr"
+SECTION = "base"
+LICENSE = "MPL-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
+
+inherit allarch
+
+SRC_URI = " \
+            file://60-polling-interval.toml \
+            "
+
+SOTA_POLLING_SEC ?= "30"
+
+do_install_append () {
+    install -m 0700 -d ${D}${libdir}/sota/conf.d
+    install -m 0644 ${WORKDIR}/60-polling-interval.toml ${D}${libdir}/sota/conf.d/60-polling-interval.toml
+
+    sed -i -e 's|@POLLING_SEC@|${SOTA_POLLING_SEC}|g' \
+           ${D}${libdir}/sota/conf.d/60-polling-interval.toml
+}
+
+FILES_${PN} = " \
+                ${libdir}/sota/conf.d/60-polling-interval.toml \
+                "
+
+# vim:set ts=4 sw=4 sts=4 expandtab:
+

--- a/recipes-sota/config/files/60-polling-interval.toml
+++ b/recipes-sota/config/files/60-polling-interval.toml
@@ -1,0 +1,2 @@
+[uptane]
+polling_sec = @POLLING_SEC@


### PR DESCRIPTION
Can be used for testing purposes after we increase the default polling interval in aktualizr. We no longer recommend anything less than an hour for production use cases, but it's still convenient to poll more frequently while testing.

FYI @alexhumphreys and @koshelev. This should probably get merged and backported (and the quickstart guide updated) before we merge https://github.com/advancedtelematic/aktualizr/pull/1212.