### PR TITLE
sota.bbclass: move sota to DISTROOVERRIDES

### DIFF
--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -1,4 +1,4 @@
-OVERRIDES .= "${@bb.utils.contains('DISTRO_FEATURES', 'sota', ':sota', '', d)}"
+DISTROOVERRIDES .= "${@bb.utils.contains('DISTRO_FEATURES', 'sota', ':sota', '', d)}"
 
 HOSTTOOLS_NONFATAL += "java"
 


### PR DESCRIPTION
Move sota to DISTROOVERRIDES from OVERRIDES, it should be a distro
overrides.

This change also let 'sota' to be in front of 'forcevariable' in
OVERRIDES, since 'forcevariable' should always be the last overrides.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>