### PR TITLE
Fix PIN_LIST in checkout-oe.sh

### DIFF
--- a/scripts/ci/checkout-oe.sh
+++ b/scripts/ci/checkout-oe.sh
@@ -45,6 +45,7 @@ for pin in $PIN_LIST; do
     IFS=":"
     read -r project rev <<< "$pin"
     xmlstarlet ed --omit-decl -L \
+        -d "/manifest/project[@name=\"$project\"]/@revision" \
         -i "/manifest/project[@name=\"$project\"]/@revision" -t attr -n "revision" -v "$rev" \
         -i "/manifest/project[@name=\"$project\"]" -t attr -n "revision" -v "$rev" \
         "$MANIFEST_FILE"


### PR DESCRIPTION
It didn't work if the manifest already had a revision specified