### PR TITLE
Fix pre-clean of repo manifests

### DIFF
--- a/scripts/ci/checkout-oe.sh
+++ b/scripts/ci/checkout-oe.sh
@@ -19,9 +19,11 @@ mkdir -p updater-repo
 
 cd updater-repo
 
-repo init -m "${MANIFEST}.xml" -u "$REMOTE_SOURCE/updater-repo"
+if [ -d .repo/manifests ]; then
+    git -C .repo/manifests reset --hard
+fi
 
-git -C .repo/manifests reset --hard
+repo init -m "${MANIFEST}.xml" -u "$REMOTE_SOURCE/updater-repo"
 
 # patch manifest:
 # - add a new "ats" remote that points to "$REMOTE_SOURCE"


### PR DESCRIPTION
Was causing problem with cache when updater-repo was updated

Another weird bash pull request, sorry.