### PR TITLE
Move `before_script` gitlab steps to `script`

### DIFF
--- a/lib/oeqa/selftest/cases/updater_qemux86_64.py
+++ b/lib/oeqa/selftest/cases/updater_qemux86_64.py
@@ -358,7 +358,7 @@ class IpSecondaryTests(OESelftestTestCase):
             self._test_ctx.append_config('SOTA_CLIENT_PROV = " aktualizr-shared-prov "')
 
         def is_ecu_registered(self, ecu_id):
-            max_number_of_tries = 40
+            max_number_of_tries = 120
             try_counter = 0
 
             # aktualizr-info is not always able to load ECU serials from DB

--- a/scripts/ci/gitlab/docker.yml
+++ b/scripts/ci/gitlab/docker.yml
@@ -10,9 +10,9 @@
   stage: docker
   services:
     - docker:18-dind
-  before_script:
-    - docker login -u gitlab-ci-token -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
   script:
+    - docker login -u gitlab-ci-token -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
+
     - docker pull "$BITBAKE_IMAGE" || docker pull "$BITBKAE_IMAGE_MASTER" || true
     - docker build --pull --cache-from "$BITBKAE_IMAGE_MASTER" --cache-from "$BITBAKE_IMAGE" -f ./scripts/ci/Dockerfile.bitbake -t "$BITBAKE_IMAGE" ./scripts/ci
     - docker push "$BITBAKE_IMAGE"
@@ -30,8 +30,8 @@
   stage: docker
   services:
     - docker:18-dind
-  before_script:
-    - docker login -u gitlab-ci-token -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
   script:
+    - docker login -u gitlab-ci-token -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
+
     - docker pull "$BITBAKE_IMAGE"
     - docker pull "$BITBAKE_CHECKOUT_IMAGE"

--- a/scripts/ci/gitlab/tests.yml
+++ b/scripts/ci/gitlab/tests.yml
@@ -24,10 +24,9 @@
     - bitbake
   variables:
     TEST_AKTUALIZR_CREDENTIALS: $CI_PROJECT_DIR/credentials.zip
-  before_script:
+  script:
     - aws s3 cp s3://ota-gitlab-ci/hereotaconnect_prod.zip credentials.zip
     - sudo /usr/local/bin/setup_kvm.sh
-  script:
     - |
       # sg is needed after adding bitbake to the kvm group (see setup_kvm.sh)
       sg kvm << EOS


### PR DESCRIPTION
So that `before_script` can be used for additional steps when sub-classing.

Will be useful for making https://github.com/advancedtelematic/aktualizr/pull/1262 work with tags.