### PR TITLE
initramfs-ostree-image: unset EXTRA_IMAGEDEPENDS to avoid extra dependencies

### DIFF
--- a/recipes-core/images/initramfs-ostree-image.bb
+++ b/recipes-core/images/initramfs-ostree-image.bb
@@ -15,6 +15,9 @@ LICENSE = "MIT"
 
 IMAGE_FSTYPES = "${INITRAMFS_FSTYPES}"
 
+# Avoid circular dependencies
+EXTRA_IMAGEDEPENDS = ""
+
 inherit core-image
 
 IMAGE_ROOTFS_SIZE = "8192"


### PR DESCRIPTION
It is common for machine configurations to set EXTRA_IMAGEDEPENDS, which
can end up causing circular dependencies when building the initramfs
image (they are usually only required for the actual rootfs image).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>