### PR TITLE
local.conf.sample: fix provisioning naming.

### DIFF
--- a/conf/local.conf.sample.append
+++ b/conf/local.conf.sample.append
@@ -8,7 +8,7 @@ MACHINE = "##MACHINE##"
 DISTRO = "poky-sota-systemd"
 
 # General SOTA setup
-#SOTA_CLIENT_PROV = "aktualizr-auto-prov"
+#SOTA_CLIENT_PROV = "aktualizr-shared-prov"
 #SOTA_PACKED_CREDENTIALS = "/path/to/credentials.zip"
 
 # Uncomment this line to start an ssh server at boot automatically


### PR DESCRIPTION
Missed that somehow when we did the renaming.