### PR TITLE
Connman 2 systemd fix

### DIFF
--- a/recipes-connectivity/connman/connman_%.bbappend
+++ b/recipes-connectivity/connman/connman_%.bbappend
@@ -1,1 +1,6 @@
 RPROVIDES_${PN} += "virtual/network-configuration"
+
+# patch to not create the resolv.conf symlink at run-time, as it's already
+# handled in the recipe and messes up with ostree
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += "file://0001-tmpfiles-script-do-not-create-the-resolv.conf-symlin.patch"

--- a/recipes-connectivity/connman/files/0001-tmpfiles-script-do-not-create-the-resolv.conf-symlin.patch
+++ b/recipes-connectivity/connman/files/0001-tmpfiles-script-do-not-create-the-resolv.conf-symlin.patch
@@ -1,0 +1,22 @@
+From 9e724a61f015304c9d72d829a66178d20e3fa980 Mon Sep 17 00:00:00 2001
+From: Laurent Bonnans <laurent.bonnans@here.com>
+Date: Wed, 31 Jul 2019 18:15:47 +0200
+Subject: [PATCH] tmpfiles script: do not create the resolv.conf symlink
+
+It's handled by yocto in our case
+
+Signed-off-by: Laurent Bonnans <laurent.bonnans@here.com>
+---
+ scripts/connman_resolvconf.conf.in | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/scripts/connman_resolvconf.conf.in b/scripts/connman_resolvconf.conf.in
+index 2d61dfe1..8a7d3071 100644
+--- a/scripts/connman_resolvconf.conf.in
++++ b/scripts/connman_resolvconf.conf.in
+@@ -1,2 +1 @@
+ d	@runstatedir@/connman	- - - -
+-L+	/etc/resolv.conf	- - - -	@runstatedir@/connman/resolv.conf
+-- 
+2.20.1
+

--- a/recipes-connectivity/networkd-dhcp-conf/files/clean-connman-symlink.service
+++ b/recipes-connectivity/networkd-dhcp-conf/files/clean-connman-symlink.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Clean up bogus symlinked resolv.conf
+Before=network-pre.target
+Wants=network-pre.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/resolvconf-clean
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-connectivity/networkd-dhcp-conf/files/resolvconf-clean
+++ b/recipes-connectivity/networkd-dhcp-conf/files/resolvconf-clean
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+if [ ! -L /etc/resolv.conf ]; then
+    exit 0
+fi
+
+# 'readlink -f' will fail if the symlink doesn't resolve to an existing path
+if readlink /etc/resolv.conf | grep -q connman; then
+    echo "Replacing resolv.conf symlink: $(readlink /etc/resolv.conf) to /etc/resolv-conf.systemd"
+    rm /etc/resolv.conf
+    ln -s /etc/resolv-conf.systemd /etc/resolv.conf
+fi

--- a/recipes-connectivity/networkd-dhcp-conf/networkd-dhcp-conf.bb
+++ b/recipes-connectivity/networkd-dhcp-conf/networkd-dhcp-conf.bb
@@ -8,21 +8,37 @@ inherit allarch systemd
 
 RPROVIDES_${PN} = "virtual/network-configuration"
 
-SRC_URI_append = " file://20-wired-dhcp.network"
+SRC_URI = " \
+  file://20-wired-dhcp.network \
+  file://resolvconf-clean \
+  file://clean-connman-symlink.service \
+  "
 PR = "r1"
 
 RDEPENDS_${PN} = "systemd"
+RCONFLICTS_${PN} = "connman"
 
 S = "${WORKDIR}"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-FILES_${PN} = "${systemd_unitdir}/network/*"
+FILES_${PN} = " \
+        ${systemd_unitdir}/network/* \
+        ${sbindir}/resolvconf-clean \
+        ${systemd_unitdir}/system/clean-connman-symlink.service \
+        "
+
+SYSTEMD_SERVICE_${PN} = "clean-connman-symlink.service"
 
 DEV_MATCH_DIRECTIVE ?= "Name=en*"
 
 do_install() {
     install -d ${D}/${systemd_unitdir}/network
-    install -m 0644 ${WORKDIR}/20-wired-dhcp.network ${D}/${systemd_unitdir}/network
+    install -m 0644 ${WORKDIR}/20-wired-dhcp.network ${D}${systemd_unitdir}/network
     sed -i -e 's|@MATCH_DIRECTIVE@|${DEV_MATCH_DIRECTIVE}|g' ${D}${systemd_unitdir}/network/20-wired-dhcp.network
+
+    install -d ${D}${sbindir}
+    install -m 0755 ${WORKDIR}/resolvconf-clean ${D}${sbindir}/resolvconf-clean
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/clean-connman-symlink.service ${D}${systemd_unitdir}/system/clean-connman-symlink.service
 }


### PR DESCRIPTION
Fix for OTA-3401.

In summary, moving from using connman to systemd-networkd broke dns.

This fix allows:
- move from current version with connman to new versions with systemd-networkd (even without hack). This could maybe be upstreamed in some form
- move from old versions with connman to this one, with a systemd hack at boot (fix the broken symlink)