### PR TITLE
Fix error during package_qa with aktualizr-ptest

### DIFF
--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -10,7 +10,7 @@ DEPENDS_append = "${@bb.utils.contains('PTEST_ENABLED', '1', ' coreutils-native 
 RDEPENDS_${PN}_class-target = "aktualizr-configs lshw"
 RDEPENDS_${PN}-host-tools = "aktualizr aktualizr-repo aktualizr-cert-provider ${@bb.utils.contains('PACKAGECONFIG', 'sota-tools', 'garage-deploy garage-push', '', d)}"
 
-RDEPENDS_${PN}-ptest += "bash cmake curl net-tools python3-misc python3-modules openssl-bin sqlite3 valgrind"
+RDEPENDS_${PN}-ptest += "bash cmake curl net-tools python3-core python3-misc python3-modules openssl-bin sqlite3 valgrind"
 
 PV = "1.0+git${SRCPV}"
 PR = "7"


### PR DESCRIPTION
Oddly, this started happening:

    ERROR: aktualizr-1.0+gitAUTOINC+03778511cc-7 do_package_qa: QA Issue:
    /usr/lib/aktualizr/ptest/src/tests/sota_tools/headers_response_server.py
    contained in package aktualizr-ptest requires /usr/bin/python3, but no
    providers found in RDEPENDS_aktualizr-ptest? [file-rdeps]

However, the python3 binary is already provided by python3-modules but
for some reason the qa check tool trips on it. We need to add an
explicit `python3-core` in the list.