### PR TITLE
layer.conf: add zeus to compatible release series

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_sota = "^${LAYERDIR}/"
 BBFILE_PRIORITY_sota = "7"
 
 LAYERDEPENDS_sota = "filesystems-layer"
-LAYERSERIES_COMPAT_sota = "thud warrior"
+LAYERSERIES_COMPAT_sota = "thud warrior zeus"


### PR DESCRIPTION
Zeus is the next OE release, scheduled to be released in October/2019.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>