### PR TITLE
Feat/better overlays

### DIFF
--- a/scripts/run-qemu-ota
+++ b/scripts/run-qemu-ota
@@ -2,7 +2,7 @@
 
 from argparse import ArgumentParser
 from subprocess import Popen
-from os.path import exists
+from os.path import exists, dirname
 import sys
 from qemucommand import QemuCommand
 
@@ -39,6 +39,16 @@ def main():
                              'This can be used to test Uptane Primary/Secondary communication.')
     parser.add_argument('-n', '--dry-run', help='Print qemu command line rather then run it', action='store_true')
     args = parser.parse_args()
+
+    if args.overlay and not exists(args.overlay) and dirname(args.overlay) and not dirname(args.overlay) == '.':
+        print('Error: please provide a file name in the current working directory. ' +
+                'Overlays do not work properly with other directories.')
+        sys.exit(1)
+    if args.overlay and exists(args.overlay) and args.imagename != parser.get_default('imagename'):
+        # qemu-img amend -o <filename> might work, but it has not yet been done
+        # successfully.
+        print('Warning: cannot change backing image of overlay after it has been created.')
+
     try:
         qemu_command = QemuCommand(args)
     except ValueError as e:

--- a/scripts/run-qemu-ota
+++ b/scripts/run-qemu-ota
@@ -55,12 +55,6 @@ def main():
         print(e.message)
         sys.exit(1)
 
-    print("Launching %s with mac address %s" % (args.imagename, qemu_command.mac_address))
-    print("To connect via SSH:")
-    print(" ssh -o StrictHostKeyChecking=no root@localhost -p %d" % qemu_command.ssh_port)
-    print("To connect to the serial console:")
-    print(" nc localhost %d" % qemu_command.serial_port)
-
     cmdline = qemu_command.command_line()
     if args.overlay and not exists(args.overlay):
         print("Overlay file %s does not yet exist, creating." % args.overlay)
@@ -69,6 +63,12 @@ def main():
             print(" ".join(img_cmdline))
         else:
             Popen(img_cmdline).wait()
+
+    print("Launching %s with mac address %s" % (args.imagename, qemu_command.mac_address))
+    print("To connect via SSH:")
+    print(" ssh -o StrictHostKeyChecking=no root@localhost -p %d" % qemu_command.ssh_port)
+    print("To connect to the serial console:")
+    print(" nc localhost %d" % qemu_command.serial_port)
 
     if args.dry_run:
         print(" ".join(cmdline))

--- a/scripts/run-qemu-ota
+++ b/scripts/run-qemu-ota
@@ -53,7 +53,7 @@ def main():
 
     cmdline = qemu_command.command_line()
     if args.overlay and not exists(args.overlay):
-        print("Image file %s does not yet exist, creating." % args.overlay)
+        print("Overlay file %s does not yet exist, creating." % args.overlay)
         img_cmdline = qemu_command.img_command_line()
         if args.dry_run:
             print(" ".join(img_cmdline))


### PR DESCRIPTION
The goal here was to copy the backing image and u-boot rom alongside the overlay file. That way you can copy the three files together to other systems and you have everything you need to reopen the overlay file. As long as you keep the files in the same directory and named with the same suffix patterns, it should work without needing to specify anything extra to `run-qemu`.

Requested by @Raigi. Let me know if this fulfills your needs!