### PR TITLE
README: update and restructure the links to the dev portal.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,6 +2,7 @@
 :toc: macro
 :toc-title:
 :aktualizr-docsroot: https://github.com/advancedtelematic/aktualizr/tree/master/docs/ota-client-guide/modules/ROOT/pages/
+:getstarted-docsroot: https://docs.ota.here.com/getstarted/dev/
 
 Meta-updater is a link:https://www.yoctoproject.org/software-overview/layers/[Yocto layer] that enables over-the-air updates (OTA) with https://github.com/ostreedev/ostree[OSTree] and https://github.com/advancedtelematic/aktualizr[Aktualizr] -- the default client for link:https://www.here.com/products/automotive/ota-technology[HERE OTA Connect].
 
@@ -11,7 +12,7 @@ https://github.com/advancedtelematic/aktualizr[Aktualizr] implements https://upt
 
 == Quickstart
 
-If you don't already have a Yocto project that you want to add OTA to, you can use the xref:dev@getstarted::raspberry-pi.adoc[HERE OTA Connect Quickstart] project to rapidly get up and running on a Raspberry Pi. It takes a standard https://www.yoctoproject.org/tools-resources/projects/poky[poky] distribution, and adds OTA and OSTree capabilities.
+If you don't already have a Yocto project that you want to add OTA to, you can use the xref:{getstarted-docsroot}get-started.html[HERE OTA Connect Quickstart] project to rapidly get up and running on a xref:{getstarted-docsroot}raspberry-pi.html[Raspberry Pi] or with xref:{getstarted-docsroot}qemuvirtualbox.html[QEMU]. It takes a standard https://www.yoctoproject.org/tools-resources/projects/poky[poky] distribution, and adds OTA and OSTree capabilities.
 
 == Dependencies
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 = meta-updater
 :toc: macro
 :toc-title:
-:aktualizr-docsroot: https://github.com/advancedtelematic/aktualizr/tree/master/docs/ota-client-guide/modules/ROOT/pages/
+:devguide-docsroot: https://docs.ota.here.com/ota-client/latest/
 :getstarted-docsroot: https://docs.ota.here.com/getstarted/dev/
 
 Meta-updater is a link:https://www.yoctoproject.org/software-overview/layers/[Yocto layer] that enables over-the-air updates (OTA) with https://github.com/ostreedev/ostree[OSTree] and https://github.com/advancedtelematic/aktualizr[Aktualizr] -- the default client for link:https://www.here.com/products/automotive/ota-technology[HERE OTA Connect].
@@ -31,45 +31,41 @@ sudo apt install ovmf
 [discrete]
 == Table of Contents
 
-The following documentation focuses on tasks that involve the meta-updater layer. If you want to get an idea of the overall developer workflow in OTA Connect, see the link:https://docs.ota.here.com/ota-client/dev/index.html[OTA Connect Developer Guide].
-[NOTE]
-====
-The following links point to files in the aktualizr repository where the source of the developer guide is stored.
-====
+The following documentation focuses on tasks that involve the meta-updater layer. If you want to get an idea of the overall developer workflow in OTA Connect, see the link:{devguide-docsroot}index.html[OTA Connect Developer Guide].
 
-* xref:{aktualizr-docsroot}supported-boards.adoc[Supported boards]
+* xref:{devguide-docsroot}supported-boards.html[Supported boards]
 +
 Find out if your board is supported and learn about the minimum hardware requirements.
 +
-* xref:{aktualizr-docsroot}build-agl.adoc[Build an Automotive Grade Linux image]
+* xref:{devguide-docsroot}build-agl.html[Build an Automotive Grade Linux image]
 +
 Learn how to use this layer as part of AGL.
 +
-* xref:{aktualizr-docsroot}add-ota-functonality-existing-yocto-project.adoc[Add OTA functionality to an existing Yocto project]
+* xref:{devguide-docsroot}add-ota-functonality-existing-yocto-project.html[Add OTA functionality to an existing Yocto project]
 +
 Learn how to add this layer to your own Yocto project.
 +
-* xref:{aktualizr-docsroot}build-configuration.adoc[SOTA-related variables in local.conf]
+* xref:{devguide-docsroot}build-configuration.html[SOTA-related variables in local.conf]
 +
 Learn how to configure OTA-related functionality when building images, including how to install custom versions of aktualizr.
 +
-* xref:{aktualizr-docsroot}recommended-clientconfig.adoc[Recommended configuration]
+* xref:{devguide-docsroot}recommended-clientconfig.html[Recommended configuration]
 +
 Learn how to optimize your build for development or production.
 +
-* xref:{aktualizr-docsroot}client-provisioning-methods.adoc[Provisoning methods]
+* xref:{devguide-docsroot}client-provisioning-methods.html[Provisoning methods]
 +
-Learn more about the methods for provisioning devices. For more detail, you may also want to read about how to xref:{aktualizr-docsroot}enable-device-cred-provisioning.adoc[enable device credential provisioning] or how to xref:{aktualizr-docsroot}simulate-device-cred-provtest.adoc[simulate it for testing].
+Learn more about the methods for provisioning devices. For more detail, you may also want to read about how to xref:{devguide-docsroot}enable-device-cred-provisioning.html[enable device credential provisioning] or how to xref:{devguide-docsroot}simulate-device-cred-provtest.html[simulate it for testing].
 +
-* xref:{aktualizr-docsroot}meta-updater-usage.adoc[Advanced usage]
+* xref:{devguide-docsroot}meta-updater-usage.html[Advanced usage]
 +
 Learn about the `garage-push` and `garage-sign` utilities, aktualizr configuration recipes, and service resource control.
 +
-* xref:{aktualizr-docsroot}meta-updater-testing.adoc[Testing with oe-selftest and ptest]
+* xref:{devguide-docsroot}meta-updater-testing.html[Testing with oe-selftest and ptest]
 +
 Learn how to use the `oe-selftest` framework for quality assurance and how to run the aktualizr test suite via ptest.
 +
-* xref:{aktualizr-docsroot}troubleshooting.adoc[Troubleshooting]
+* xref:{devguide-docsroot}troubleshooting.html[Troubleshooting]
 +
 Get help on common problems.
 

--- a/README.adoc
+++ b/README.adoc
@@ -7,7 +7,7 @@ Meta-updater is a link:https://www.yoctoproject.org/software-overview/layers/[Yo
 
 https://github.com/ostreedev/ostree[OSTree] is a tool for atomic full file system upgrades with rollback capability. OSTree has several advantages over traditional dual-bank systems, but the most important one is that it minimizes network bandwidth and data storage footprint by sharing files with the same contents across file system deployments.
 
-https://github.com/advancedtelematic/aktualizr[Aktualizr] (and https://github.com/advancedtelematic/rvi_sota_client[RVI SOTA client]) add authentication and provisioning capabilities to OTA and are integrated with OSTree. You can connect with these open-source applications or sign up for a free account at https://connect.ota.here.com/[HERE OTA Connect] to get started.
+https://github.com/advancedtelematic/aktualizr[Aktualizr] implements https://uptane.github.io/uptane-standard/uptane-standard.html[Uptane], supports device authentication and provisioning, and is integrated with OSTree. You can connect aktualizr to your own server solution or sign up for a free account at https://connect.ota.here.com/[HERE OTA Connect] to get started.
 
 == Quickstart
 
@@ -36,37 +36,41 @@ The following documentation focuses on tasks that involve the meta-updater layer
 The following links point to files in the aktualizr repository where the source of the developer guide is stored.
 ====
 
-* xref:{aktualizr-docsroot}meta-updater-build.adoc[Build]
-+
-Learn how to use this layer to build a basic disk image and add it to your own Yocto project.
-+
 * xref:{aktualizr-docsroot}supported-boards.adoc[Supported boards]
 +
 Find out if your board is supported and learn about the minimum hardware requirements.
 +
+* xref:{aktualizr-docsroot}build-agl.adoc[Build an Automotive Grade Linux image]
++
+Learn how to use this layer as part of AGL.
++
+* xref:{aktualizr-docsroot}add-ota-functonality-existing-yocto-project.adoc[Add OTA functionality to an existing Yocto project]
++
+Learn how to add this layer to your own Yocto project.
++
 * xref:{aktualizr-docsroot}build-configuration.adoc[SOTA-related variables in local.conf]
 +
-Learn how to configure OTA-related functionality when building disk images.
+Learn how to configure OTA-related functionality when building images, including how to install custom versions of aktualizr.
 +
-* xref:{aktualizr-docsroot}meta-updater-usage.adoc[Usage]
+* xref:{aktualizr-docsroot}recommended-clientconfig.adoc[Recommended configuration]
 +
-Learn about the `garage-push` and `garage-sign` utilities, aktualizr configuration and service resource control, and OSTree.
+Learn how to optimize your build for development or production.
 +
-* xref:{aktualizr-docsroot}meta-updater-dev-config.adoc[Development configuration]
+* xref:{aktualizr-docsroot}client-provisioning-methods.adoc[Provisoning methods]
 +
-Learn how to configure logging, install custom versions of aktualizr, and override the version indicator for sofware updates.
+Learn more about the methods for provisioning devices. For more detail, you may also want to read about how to xref:{aktualizr-docsroot}enable-device-cred-provisioning.adoc[enable device credential provisioning] or how to xref:{aktualizr-docsroot}simulate-device-cred-provtest.adoc[simulate it for testing].
 +
-* xref:{aktualizr-docsroot}meta-updater-testing.adoc#_qa_with_oe_selftest[QA with oe-selftest]
+* xref:{aktualizr-docsroot}meta-updater-usage.adoc[Advanced usage]
 +
-Learn how to use the `oe-selftest` framework for quality assurance.
+Learn about the `garage-push` and `garage-sign` utilities, aktualizr configuration recipes, and service resource control.
 +
-* xref:{aktualizr-docsroot}meta-updater-testing.adoc#_aktualizr_test_suite_with_ptest[Aktualizr test suite with ptest]
+* xref:{aktualizr-docsroot}meta-updater-testing.adoc[Testing with oe-selftest and ptest]
 +
-Learn how to enable Yocto's package test functionality and run parts of the aktualizr test suite.
+Learn how to use the `oe-selftest` framework for quality assurance and how to run the aktualizr test suite via ptest.
 +
-* xref:{aktualizr-docsroot}meta-updater-provisioning-methods.adoc[Provisoning methods]
+* xref:{aktualizr-docsroot}troubleshooting.adoc[Troubleshooting]
 +
-Learn how to enable different methods for provisioning devices.
+Get help on common problems.
 
 == License
 


### PR DESCRIPTION
In the wake of https://github.com/advancedtelematic/aktualizr/pull/1410. That PR must get merged before this can be.

Also: should the links point to the docs portal instead of aktualizr's github pages?