### PR TITLE
image_types_ostree: Fix OSTree ref-bindings

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -168,7 +168,8 @@ IMAGE_CMD_ostreecommit () {
            --skip-if-unchanged \
            --branch=${OSTREE_BRANCHNAME} \
            --subject="${OSTREE_COMMIT_SUBJECT}" \
-           --body="${OSTREE_COMMIT_BODY}"
+           --body="${OSTREE_COMMIT_BODY}" \
+           --bind-ref="${OSTREE_BRANCHNAME}-${IMAGE_BASENAME}"
 
     if [ "${OSTREE_UPDATE_SUMMARY}" = "1" ]; then
         ostree --repo=${OSTREE_REPO} summary -u


### PR DESCRIPTION
This fixes an unforeseen issue caused by https://github.com/advancedtelematic/meta-updater/pull/489.

When `ostree commit` is used it creates a ref with the passed in `OSTREE_BRANCHNAME`. The resulting ref file in ostree_repo contains the commit hash pertaining to this ref. This hash can then be used to locate the respective hash.commit file in ostree_repo which contains the metadata for that commit. One such piece of metadata is the ref-binding which is a list of ref names that correspond to this commit. 

The `ostree refs --create` added in the above pull request introduced an issue however. Using `ostree refs --create` creates a ref file in ostree_repo with the same hash as a preexisting commit. But this doesn't seem to modify the commit metadata at all.

This leads to problems when manipulating this ostree_repo with certain ostree commands. Namely `ostree pull` will fail when pulling the ref created by `ostree refs --create`. This is because `ostree pull` verifies the ref-bindings metadata to see if the ref that is being pulled is listed in the ref-bindings for the commit metadata being referenced by that ref. 

In short any refs created by `ostree refs --create` will fail when pulled by `ostree pull` since they lack the necessary metadata to pass the basic security verification.

What this commit does is add the `--bind-refs` option to `ostree commit` which adds the passed in string to be added in that commits ref-bindings list. Note that this only adds a name to the ref-bindings list, and does not actually create the ref, but here the ref will be created after the commit anyways.