### PR TITLE
networkd-dhcp-conf: Remove allarch.

### DIFF
--- a/recipes-connectivity/networkd-dhcp-conf/networkd-dhcp-conf.bb
+++ b/recipes-connectivity/networkd-dhcp-conf/networkd-dhcp-conf.bb
@@ -4,7 +4,7 @@ interfaces through systemd-networkd"
 LICENSE = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
 
-inherit allarch systemd
+inherit systemd
 
 RPROVIDES_${PN} = "virtual/network-configuration"
 


### PR DESCRIPTION
We were setting PACKAGE_ARCH to MACHINE_ARCH anyway, so this wasn't helping anything.

Addresses the last comment from @shr-project in https://github.com/advancedtelematic/meta-updater/issues/603#issuecomment-546544016.