### PR TITLE
Fix aktualizr-ptest breakage

### DIFF
--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -77,6 +77,10 @@ do_configure_prepend() {
     fi
 }
 
+do_compile_ptest() {
+    cmake_runcmake_build --target build_tests "${PARALLEL_MAKE}"
+}
+
 do_install_ptest() {
     # copy the complete source directory (contains build)
     cp -r ${B}/ ${D}/${PTEST_PATH}/build


### PR DESCRIPTION
The compile step was removed by mistake in ec1ac0617b120813d6450dffe1aa8d4868e37332!