### PR TITLE
Fix uart output on recent raspberrypi3

### DIFF
--- a/classes/sota_raspberrypi.bbclass
+++ b/classes/sota_raspberrypi.bbclass
@@ -44,9 +44,9 @@ IMAGE_BOOT_FILES_sota = "bcm2835-bootfiles/* \
                          "
 
 # OSTree puts its own boot.scr to bcm2835-bootfiles
-# raspberrypi4 needs dtb in /boot partition so that they can be read by the
-# firmware
-IMAGE_BOOT_FILES_append_sota_raspberrypi4 = "${@make_dtb_boot_files(d)}"
+# rpi4 and recent rpi3 firmwares needs dtb in /boot partition
+# so that they can be read by the firmware
+IMAGE_BOOT_FILES_append_sota = "${@make_dtb_boot_files(d)}"
 
 # Just the overlays that will be used should be listed
 KERNEL_DEVICETREE_raspberrypi2_sota ?= " bcm2709-rpi-2-b.dtb "

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -30,7 +30,7 @@ SRC_URI = " \
 SRC_URI[garagesign.md5sum] = "de0877ecb693fd48ec11052e51b0ff1a"
 SRC_URI[garagesign.sha256sum] = "cf25759574c9c1206835daeaf6fc345f6db7b5ccdb95fb828c86d7451f78f0aa"
 
-SRCREV = "9677f025abbb958ad36d4b58cae1dd4fe5750cf0"
+SRCREV = "1c2f495e47a41cc7c9ad969ff42496208ad6b23a"
 BRANCH ?= "master"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
The broadcom firmware now needs device trees to be present in/boot to
set it up.