### PR TITLE
image_types_ostree.bbclass: do not inherit distro_features_check

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -1,5 +1,7 @@
 # OSTree deployment
-inherit distro_features_check
+inherit features_check
+
+REQUIRED_DISTRO_FEATURES = "usrmerge"
 
 OSTREE_KERNEL ??= "${KERNEL_IMAGETYPE}"
 OSTREE_ROOTFS ??= "${WORKDIR}/ostree-rootfs"
@@ -16,7 +18,6 @@ IMAGE_CMD_TAR = "tar --xattrs --xattrs-include=*"
 CONVERSION_CMD_tar = "touch ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type}; ${IMAGE_CMD_TAR} --numeric-owner -cf ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type}.tar -C ${TAR_IMAGE_ROOTFS} . || [ $? -eq 1 ]"
 CONVERSIONTYPES_append = " tar"
 
-REQUIRED_DISTRO_FEATURES = "usrmerge"
 TAR_IMAGE_ROOTFS_task-image-ostree = "${OSTREE_ROOTFS}"
 do_image_ostree[dirs] = "${OSTREE_ROOTFS}"
 do_image_ostree[cleandirs] = "${OSTREE_ROOTFS}"


### PR DESCRIPTION
Change to inherit features_check, since distro_features_check has been
deprecated in OE.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>