### PR TITLE
build and run image without ostree support for qemux86-64

### DIFF
--- a/conf/local.conf.nonostree.append
+++ b/conf/local.conf.nonostree.append
@@ -1,0 +1,11 @@
+
+DISTRO_FEATURES_append = " systemd"
+VIRTUAL-RUNTIME_init_manager = "systemd"
+
+PREFERRED_RPROVIDER_virtual/network-configuration ??= "networkd-dhcp-conf"
+
+SOTA_DEPLOY_CREDENTIALS ?= "1"
+PACKAGECONFIG_pn-aktualizr = ""
+
+IMAGE_INSTALL_append += "aktualizr"
+IMAGE_INSTALL_append += "aktualizr-shared-prov"

--- a/scripts/envsetup.sh
+++ b/scripts/envsetup.sh
@@ -5,17 +5,24 @@ MACHINE="$1"
 BUILDDIR="build"
 DISTRO="poky-sota-systemd"
 BASE_CONF="local.conf.base.append"
-declare -A supported_distros=( ["poky-sota-systemd"]="local.conf.systemd.append" ["poky-sota"]="local.conf.base.append" )
 
-[[ "$#" -lt 1 ]] && { echo "Usage: ${SCRIPT} <machine> [builddir] [distro=< poky-sota-systemd | poky-sota >]"; return 1; }
+# A definition of a dictionary with a list of configuration files that must be appended
+# to resulting conf/local.conf file for each particular distribution.
+declare -A supported_distros=(
+    ["poky-sota-systemd"]="local.conf.systemd.append"
+    ["poky-sota"]="local.conf.base.append"
+    ["poky"]="local.conf.systemd.append local.conf.nonostree.append"
+)
+
+[[ "$#" -lt 1 ]] && { echo "Usage: ${SCRIPT} <machine> [builddir] [distro=< poky-sota-systemd | poky-sota | poky >]"; return 1; }
 [[ "$#" -ge 2 ]] && { BUILDDIR="$2"; }
 [[ "$#" -eq 3 ]] && { DISTRO="$3"; }
 
 # detect if this script is sourced: see http://stackoverflow.com/a/38128348/6255594
 SOURCED=0
-if [ -n "$ZSH_EVAL_CONTEXT" ]; then
+if [[ -n "$ZSH_EVAL_CONTEXT" ]]; then
   [[ "$ZSH_EVAL_CONTEXT" =~ :file$ ]] && { SOURCED=1; SOURCEDIR=$(cd "$(dirname -- "$0")" && pwd -P); }
-elif [ -n "$BASH_VERSION" ]; then
+elif [[ -n "$BASH_VERSION" ]]; then
   [[ "$0" != "${BASH_SOURCE[0]}" ]] && { SOURCED=1; SOURCEDIR=$(cd "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P); }
 fi
 
@@ -26,23 +33,25 @@ if [[ $SOURCED -ne 1 ]]; then
 fi
 
 METADIR=${METADIR:-${SOURCEDIR}/../..}
-DISTRO_CONF=${supported_distros[$DISTRO]}
-[[ -n $DISTRO_CONF ]] && { echo "Using $DISTRO_CONF for the specified distro $DISTRO"; } || { echo "The specified distro $DISTRO is not supported"; return 1; }
 
 if [[ ! -f "${BUILDDIR}/conf/local.conf" ]]; then
+  declare -a DISTRO_CONFIGS=${supported_distros[$DISTRO]}
+  [[ -n ${DISTRO_CONFIGS[@]} ]] && { echo "Using (${DISTRO_CONFIGS[*]}) for the specified distro '$DISTRO'"; } || { echo "The specified distro $DISTRO is not supported"; return 1; }
+
   source "$METADIR/poky/oe-init-build-env" "$BUILDDIR"
 
   echo "METADIR  := \"\${@os.path.abspath('${METADIR}')}\"" >> conf/bblayers.conf
   cat "${METADIR}/meta-updater/conf/include/bblayers/sota.inc" >> conf/bblayers.conf
   cat "${METADIR}/meta-updater/conf/include/bblayers/sota_${MACHINE}.inc" >> conf/bblayers.conf
-
   sed -e "s/##MACHINE##/$MACHINE/g" \
       -e "s/##DISTRO##/$DISTRO/g" \
-	 "${METADIR}/meta-updater/conf/$BASE_CONF" >> conf/local.conf
+      "${METADIR}/meta-updater/conf/$BASE_CONF" >> conf/local.conf
 
-  if [ "$BASE_CONF" != "$DISTRO_CONF" ]; then
-    cat "${METADIR}/meta-updater/conf/$DISTRO_CONF" >> conf/local.conf
-  fi
+  for config in ${DISTRO_CONFIGS[@]}; do
+    if [[ "$BASE_CONF" != "$config" ]]; then
+      cat "${METADIR}/meta-updater/conf/$config" >> conf/local.conf
+    fi
+  done
 else
   source "$METADIR/poky/oe-init-build-env" "$BUILDDIR"
 fi

--- a/scripts/envsetup.sh
+++ b/scripts/envsetup.sh
@@ -45,7 +45,7 @@ if [[ ! -f "${BUILDDIR}/conf/local.conf" ]]; then
   cat "${METADIR}/meta-updater/conf/include/bblayers/sota_${MACHINE}.inc" >> conf/bblayers.conf
   sed -e "s/##MACHINE##/$MACHINE/g" \
       -e "s/##DISTRO##/$DISTRO/g" \
-      "${METADIR}/meta-updater/conf/$BASE_CONF" >> conf/local.conf
+         "${METADIR}/meta-updater/conf/$BASE_CONF" >> conf/local.conf
 
   for config in ${DISTRO_CONFIGS[@]}; do
     if [[ "$BASE_CONF" != "$config" ]]; then

--- a/scripts/qemucommand.py
+++ b/scripts/qemucommand.py
@@ -41,7 +41,7 @@ def random_mac():
 class QemuCommand(object):
     def __init__(self, args):
         print(args)
-        self.enable_u_boot = None
+        self.enable_u_boot = True
         self.dry_run = args.dry_run
         self.overlay = args.overlay
         self.host_fwd = None

--- a/scripts/run-qemu-ota
+++ b/scripts/run-qemu-ota
@@ -13,6 +13,9 @@ def main():
     parser = ArgumentParser(description='Run meta-updater image in qemu')
     parser.add_argument('imagename', default='core-image-minimal', nargs='?',
                         help="Either the name of the bitbake image target, or a path to the image to run")
+    parser.add_argument('--uboot-enable', default='yes',
+                        help='(yes/no). Determines whether or not to use U-Boot loader for running image, '
+                             'if yes then u-boot binary file will be passed as -bios option into QEMU cmd line.')
     parser.add_argument('mac', default=None, nargs='?')
     parser.add_argument('--dir', default=DEFAULT_DIR,
                         help='Path to build directory containing the image and u-boot-qemux86-64.rom')


### PR DESCRIPTION
Signed-off-by: Kostiantyn Bushko <kbushko@intellias.com>
This is draft PR for non OSTree image build, currently only for qemyx86-64.
1. Setup environment:
    $ source envsetup.sh qemux86-64 "path-to-yocto-build-folder" poky
2. Build:
    $bitbake core-image-minimal
3. Run QEMU:
    $ ./run-qemu-ota --uboot-enable=no
  
