### PR TITLE
Add --uboot flag to specify path to a custom u-boot rom.

### DIFF
--- a/lib/oeqa/selftest/cases/testutils.py
+++ b/lib/oeqa/selftest/cases/testutils.py
@@ -33,6 +33,7 @@ def qemu_boot_image(imagename, **kwargs):
     # subdirectory.
     args.dir = 'tmp/deploy/images'
     args.efi = kwargs.get('efi', False)
+    args.bootloader = kwargs.get('bootloader', None)
     args.machine = kwargs.get('machine', None)
     args.mem = kwargs.get('mem', '128M')
     qemu_use_kvm = get_bb_var("QEMU_USE_KVM")

--- a/scripts/qemucommand.py
+++ b/scripts/qemucommand.py
@@ -58,6 +58,8 @@ class QemuCommand(object):
         if args.efi:
             self.bios = 'OVMF.fd'
         else:
+            if args.bootloader:
+                uboot_path = args.bootloader
             uboot_path = abspath(join(args.dir, self.machine, 'u-boot-qemux86-64.rom'))
             if self.overlay:
                 new_uboot_path = self.overlay + '.u-boot.rom'

--- a/scripts/run-qemu-ota
+++ b/scripts/run-qemu-ota
@@ -20,6 +20,7 @@ def main():
                         help='Boot using UEFI rather than U-Boot. This requires the image to be built with ' +
                              'OSTREE_BOOTLOADER = "grub" and OVMF.fd firmware to be installed (try "apt install ovmf")',
                         action='store_true')
+    parser.add_argument('--bootloader', default=None, help="Path to bootloader, e.g. a u-boot ROM")
     parser.add_argument('--machine', default=None, help="Target MACHINE")
     kvm_group = parser.add_argument_group()
     kvm_group.add_argument('--force-kvm', help='Force use of KVM (default is to autodetect)',


### PR DESCRIPTION
This is intended to help with keeping around older versions of images with a similarly old bootloader.

@Raigi I'm hoping this is what you *actually* need for keeping around old images. Using this should give you the same features as https://github.com/advancedtelematic/meta-updater/pull/599 but without having to mess with clearing credentials. To use this, you'll need to copy the ota-ext4 image and the u-boot rom in your deploy directory and then launch qemu with something like `../meta-updater/scripts/run-qemu-ota --no-gui --machine qemux86-64 --uboot ./u-boot-qemux86-64.rom ./core-image-minimal-qemux86-64.ota-ext4`. What do you think?