### PR TITLE
aktualizr: Bump to latest for ptest fixes for C API tests.

### DIFF
--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -30,7 +30,7 @@ SRC_URI = " \
 SRC_URI[garagesign.md5sum] = "3d38908f9b536a02cc73778b11bbc32e"
 SRC_URI[garagesign.sha256sum] = "eceeb16a781e0e8d1f554defbcd5bbcea86d448ebd350fc6a2529372bf867dba"
 
-SRCREV = "662aa23f0b9c97a2c93a428438dacae72333c751"
+SRCREV = "b625d1583166fd04a6c3789df7241724ef54204d"
 BRANCH ?= "master"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Still haven't sorted out why `aktualizr_test` is failing, though.