### PR TITLE
Force a simple reproducible build mechanism

### DIFF
--- a/conf/distro/sota.conf.inc
+++ b/conf/distro/sota.conf.inc
@@ -11,9 +11,10 @@ INHERIT += " sota"
 USER_CLASSES_remove = "image-prelink"
 
 # Enable reproducible builds. Use 0 as mtime, the same as OSTree is using.
+INHERIT_remove = "reproducible_build"
 INHERIT += "reproducible_build_simple"
 
-export SOURCE_DATE_EPOCH ?= "0"
-REPRODUCIBLE_TIMESTAMP_ROOTFS ?= "0"
+export SOURCE_DATE_EPOCH = "0"
+REPRODUCIBLE_TIMESTAMP_ROOTFS = "0"
 
 HOSTTOOLS_append = " sync sha256sum"


### PR DESCRIPTION
In 25a17f0346ab05b3212bb280e4a8b622bcf99bce, poky sets
reproducible_build by defaults. However, it is quite complex as it tries
to compute a plausible timestamp from source files, in a reproducible
ways.

Setting the timestamps to 0, just like ostree, is probably safer in our
case, so let's switch to our old behavior.

Tagging @agners who originally proposed this enhancement.