### PR TITLE
Set PKCS11_ENGINE_PATH when using aktualizr with HSM

### DIFF
--- a/recipes-sota/aktualizr/aktualizr-device-prov-hsm.bb
+++ b/recipes-sota/aktualizr/aktualizr-device-prov-hsm.bb
@@ -14,7 +14,7 @@ DEPENDS = "aktualizr"
 # If the config file from aktualizr used here is changed, you will need to bump
 # the version here because of SIGGEN_EXCLUDE_SAFE_RECIPE_DEPS!
 PV = "1.0"
-PR = "6"
+PR = "7"
 
 SRC_URI = ""
 

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -30,7 +30,7 @@ SRC_URI = " \
 SRC_URI[garagesign.md5sum] = "3d38908f9b536a02cc73778b11bbc32e"
 SRC_URI[garagesign.sha256sum] = "eceeb16a781e0e8d1f554defbcd5bbcea86d448ebd350fc6a2529372bf867dba"
 
-SRCREV = "b625d1583166fd04a6c3789df7241724ef54204d"
+SRCREV = "6b1da3e473f3c9963a3221607dabc4d0cde06968"
 BRANCH ?= "master"
 
 S = "${WORKDIR}/git"
@@ -48,12 +48,13 @@ SYSTEMD_SERVICE_${PN}-secondary = "aktualizr-secondary.service"
 EXTRA_OECMAKE = "-DCMAKE_BUILD_TYPE=Release ${@bb.utils.contains('PTEST_ENABLED', '1', '-DTESTSUITE_VALGRIND=on', '', d)}"
 
 GARAGE_SIGN_OPS = "${@ d.expand('-DGARAGE_SIGN_ARCHIVE=${WORKDIR}/cli-${GARAGE_SIGN_PV}.tgz') if d.getVar('GARAGE_SIGN_AUTOVERSION') != '1' else ''}"
+PKCS11_ENGINE_PATH = "${libdir}/engines-1.1/pkcs11.so"
 
 PACKAGECONFIG ?= "ostree ${@bb.utils.filter('SOTA_CLIENT_FEATURES', 'hsm serialcan ubootenv', d)}"
 PACKAGECONFIG_class-native = "sota-tools"
 PACKAGECONFIG[warning-as-error] = "-DWARNING_AS_ERROR=ON,-DWARNING_AS_ERROR=OFF,"
 PACKAGECONFIG[ostree] = "-DBUILD_OSTREE=ON,-DBUILD_OSTREE=OFF,ostree,"
-PACKAGECONFIG[hsm] = "-DBUILD_P11=ON,-DBUILD_P11=OFF,libp11,"
+PACKAGECONFIG[hsm] = "-DBUILD_P11=ON -DPKCS11_ENGINE_PATH=${PKCS11_ENGINE_PATH},-DBUILD_P11=OFF,libp11,"
 PACKAGECONFIG[sota-tools] = "-DBUILD_SOTA_TOOLS=ON ${GARAGE_SIGN_OPS},-DBUILD_SOTA_TOOLS=OFF,glib-2.0,"
 PACKAGECONFIG[load-tests] = "-DBUILD_LOAD_TESTS=ON,-DBUILD_LOAD_TESTS=OFF,"
 PACKAGECONFIG[serialcan] = ",,,slcand-start"


### PR DESCRIPTION
Depends on https://github.com/advancedtelematic/aktualizr/pull/1471.