### PR TITLE
Don't trigger otf on nightly meta-updater schedules

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -109,6 +109,7 @@ trigger-otf-on-pr:
   when: always
   except:
     - pushes
+    - schedules
   script:
     - apk add --no-cache curl
     - curl -X POST -F "token=$CI_JOB_TOKEN" -F "ref=master" -F "variables[BITBAKE_JOB_ONLY]=true" -F "variables[BITBAKE_ENV]=warrior" -F "variables[PROJECT_NAME]=meta-updater" -F "variables[PROJECT_SHA]=$CI_COMMIT_SHA" https://main.gitlab.in.here.com/api/v4/projects/163/trigger/pipeline


### PR DESCRIPTION
Nightly schedules are interfering with oft pipeline nightly schedules, so I would like to disable meta-updater pipelines from triggering otf on schedules.