### PR TITLE
meta: add python to HOSTTOOLS_NONFATAL

### DIFF
--- a/classes/image_repo_manifest.bbclass
+++ b/classes/image_repo_manifest.bbclass
@@ -9,7 +9,7 @@
 # For more information, see:
 # https://web.archive.org/web/20161224194009/https://wiki.cyanogenmod.org/w/Doc:_Using_manifests 
 
-HOSTTOOLS_NONFATAL += " repo "
+HOSTTOOLS_NONFATAL += "repo python"
 
 # Write build information to target filesystem
 buildinfo_manifest () {

--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -8,7 +8,7 @@ SOTA_DEPLOY_CREDENTIALS ?= "1"
 SOTA_HARDWARE_ID ??= "${MACHINE}"
 
 IMAGE_INSTALL_append_sota = " ostree os-release ${SOTA_CLIENT} ${SOTA_CLIENT_PROV}"
-IMAGE_CLASSES += " image_types_ostree image_types_ota"
+IMAGE_CLASSES += " image_types_ostree image_types_ota image_repo_manifest"
 
 IMAGE_FSTYPES += "${@bb.utils.contains('DISTRO_FEATURES', 'sota', 'ostreepush garagesign garagecheck ota-ext4 wic', ' ', d)}"
 IMAGE_FSTYPES += "${@bb.utils.contains('BUILD_OSTREE_TARBALL', '1', 'ostree.tar.bz2', ' ', d)}"
@@ -53,4 +53,4 @@ SOTA_MACHINE_freedom-u540 ?= "freedom-u540"
 SOTA_OVERRIDES_BLACKLIST = "ostree ota"
 SOTA_REQUIRED_VARIABLES = "OSTREE_REPO OSTREE_BRANCHNAME OSTREE_OSNAME OSTREE_BOOTLOADER OSTREE_BOOT_PARTITION GARAGE_SIGN_REPO GARAGE_TARGET_NAME"
 
-inherit sota_sanity sota_${SOTA_MACHINE} image_repo_manifest
+inherit sota_sanity sota_${SOTA_MACHINE}


### PR DESCRIPTION
repo is requiring python to be able to work correctly, add python to
HOSTTOOLS_NONFATAL as well, meanwhile, combine HOSTTOOLS_NONFATAL
definitions in sota.bbclass.

image_repo_manifest is actually a image bbclass, move it to
IMAGE_CLASSES instead of inheriting it in sota.bbclass.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>