### PR TITLE
QEMU run script option: allowing to pass qemu <hostfwd> as an optiona…

### DIFF
--- a/scripts/qemucommand.py
+++ b/scripts/qemucommand.py
@@ -128,7 +128,7 @@ class QemuCommand(object):
         self.secondary_network = args.secondary_network
 
         # Append additional port forwarding to QEMU command line.
-        if args.host_forward:
+        if hasattr(args, 'host_forward'):
             self.host_fwd = args.host_forward
 
     def command_line(self):

--- a/scripts/qemucommand.py
+++ b/scripts/qemucommand.py
@@ -42,6 +42,8 @@ class QemuCommand(object):
     def __init__(self, args):
         self.dry_run = args.dry_run
         self.overlay = args.overlay
+        self.host_fwd = None
+
         if args.machine:
             self.machine = args.machine
         else:
@@ -125,10 +127,17 @@ class QemuCommand(object):
         self.pcap = args.pcap
         self.secondary_network = args.secondary_network
 
+        # Append additional port forwarding to QEMU command line.
+        if args.host_forward:
+            self.host_fwd = args.host_forward
+
     def command_line(self):
         netuser = 'user,hostfwd=tcp:0.0.0.0:%d-:22,restrict=off' % self.ssh_port
         if self.gdb:
             netuser += ',hostfwd=tcp:0.0.0.0:2159-:2159'
+        if self.host_fwd:
+            netuser += ",hostfwd=" + self.host_fwd
+
         cmdline = [
             "qemu-system-x86_64",
             "-bios", self.bios

--- a/scripts/run-qemu-ota
+++ b/scripts/run-qemu-ota
@@ -39,6 +39,12 @@ def main():
                         help='Give the image a second network card connected to a virtual network. ' +
                              'This can be used to test Uptane Primary/Secondary communication.')
     parser.add_argument('-n', '--dry-run', help='Print qemu command line rather then run it', action='store_true')
+    parser.add_argument('--host-forward',
+                        help='Redirect incoming TCP or UDP connections to the host port. '
+                             'Example forwarding guest port 10050 to the host port 10555:'
+                             '--host-forward="tcp:0.0.0.0:10556-:10050". '
+                             'For more details please refer to QEMU man page, option <hostfwd>. '
+                             'https://manpages.debian.org/testing/qemu-system-x86/qemu-system-x86_64.1.en.html')
     args = parser.parse_args()
 
     if args.overlay and not exists(args.overlay) and dirname(args.overlay) and not dirname(args.overlay) == '.':


### PR DESCRIPTION
…l argument.

Added a new QEMU command line argument <--host-forward> which allows pass arguments for QEMU option <hostfwd> an an optional arguments. 
This option is currently necessary only for running the Zabbix agent on QEMU. 

Signed-off-by: Kostiantyn Bushko <kbushko@intellias.com>