### PR TITLE
aktualizr: relies on nss-lookup.target

### DIFF
--- a/recipes-sota/aktualizr/files/aktualizr.service
+++ b/recipes-sota/aktualizr/files/aktualizr.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Aktualizr SOTA Client
-After=network.target
+After=network.target nss-lookup.target
 
 [Service]
 RestartSec=10


### PR DESCRIPTION
aktualizr.service needs run after nss-lookup.target to ensure DNS
resolving is ready.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>