### PR TITLE
Enable internet access on Secondary

### DIFF
--- a/recipes-test/demo-network-config/secondary-network-config.bb
+++ b/recipes-test/demo-network-config/secondary-network-config.bb
@@ -21,7 +21,7 @@ do_install() {
 
 SECONDARY_IP ?= "10.0.3.2"
 IP_ADDR = "${SECONDARY_IP}"
-CONF_TYPE = "static"
+CONF_TYPE ?= "${@ 'multihomed' if d.getVar('MACHINE') == 'raspberrypi3' and d.getVar('RPI_WIFI_ENABLE') != '1' else 'static'}"
 
 require network-config.inc
 


### PR DESCRIPTION
- Allow Secondary to get a dynamic IP address from a router's DHCP server so it has an access to Internet. Statically defined IP address is still there and dedicated solely for communication with Primary.

- bump the latest aktualizr version that fixes the target name (filepath) reported to BE in a device manifest.