### PR TITLE
image_types_ostree: set version metadata field

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -5,6 +5,7 @@ OSTREE_KERNEL ??= "${KERNEL_IMAGETYPE}"
 OSTREE_ROOTFS ??= "${WORKDIR}/ostree-rootfs"
 OSTREE_COMMIT_SUBJECT ??= "Commit-id: ${IMAGE_NAME}"
 OSTREE_COMMIT_BODY ??= ""
+OSTREE_COMMIT_VERSION ??= "${DISTRO_VERSION}"
 OSTREE_UPDATE_SUMMARY ??= "0"
 OSTREE_DEPLOY_DEVICETREE ??= "0"
 
@@ -169,6 +170,7 @@ IMAGE_CMD_ostreecommit () {
            --branch=${OSTREE_BRANCHNAME} \
            --subject="${OSTREE_COMMIT_SUBJECT}" \
            --body="${OSTREE_COMMIT_BODY}" \
+           --add-metadata-string=version="${OSTREE_COMMIT_VERSION}" \
            --bind-ref="${OSTREE_BRANCHNAME}-${IMAGE_BASENAME}"
 
     if [ "${OSTREE_UPDATE_SUMMARY}" = "1" ]; then


### PR DESCRIPTION
OSTree uses the "version" metadata field in various places, e.g. in
ostree admin status. Use DISTRO_VERSION as default version number
source. This gives a more human readable version number to a
particular OSTree:
$ ostree admin status
* torizon f1825d8a8f89c48cc0915ea059bd23463a97655757a53ae0ab0fe7a97e1ebeb2.0
    Version: 3.0+snapshot-20200128
    origin refspec: f1825d8a8f89c48cc0915ea059bd23463a97655757a53ae0ab0fe7a97e1ebeb

Signed-off-by: Stefan Agner <stefan.agner@toradex.com>