### PR TITLE
connman: Only apply our patch to 1.35.

### DIFF
--- a/recipes-connectivity/connman/connman_%.bbappend
+++ b/recipes-connectivity/connman/connman_%.bbappend
@@ -1,6 +1,1 @@
 RPROVIDES_${PN} += "virtual/network-configuration"
-
-# patch to not create the resolv.conf symlink at run-time, as it's already
-# handled in the recipe and messes up with ostree
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
-SRC_URI += "file://0001-tmpfiles-script-do-not-create-the-resolv.conf-symlin.patch"

--- a/recipes-connectivity/connman/connman_1.35.bbappend
+++ b/recipes-connectivity/connman/connman_1.35.bbappend
@@ -1,0 +1,6 @@
+RPROVIDES_${PN} += "virtual/network-configuration"
+
+# patch to not create the resolv.conf symlink at run-time, as it's already
+# handled in the recipe and messes up with ostree
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += "file://0001-tmpfiles-script-do-not-create-the-resolv.conf-symlin.patch"


### PR DESCRIPTION
Also still set RPROVIDES for all other versions.

Fixes the AGL build if we want to bump the pinned versions of meta-updater to the latest.