### PR TITLE
Rename defconfig and bootfiles

### DIFF
--- a/classes/sota_m3ulcb.bbclass
+++ b/classes/sota_m3ulcb.bbclass
@@ -1,11 +1,12 @@
 # Commit united image to OSTree, not just uImage
 OSTREE_KERNEL = "Image"
 
-EXTRA_IMAGEDEPENDS_append_sota = " m3ulcb-ota-bootfiles"
-IMAGE_BOOT_FILES_sota += "m3ulcb-ota-bootfiles/*"
+EXTRA_IMAGEDEPENDS_append_sota = " renesas-ota-bootfiles"
+IMAGE_BOOT_FILES_sota += "renesas-ota-bootfiles/*"
 
 OSTREE_BOOTLOADER ?= "u-boot"
-UBOOT_MACHINE_sota = "m3ulcb_defconfig"
+
+UBOOT_MACHINE_sota = "${@d.getVar('SOC_FAMILY').split(':')[1]}_ulcb_defconfig"
 
 PREFERRED_RPROVIDER_virtual/network-configuration ?= "connman"
 IMAGE_INSTALL_append_sota = " virtual/network-configuration "


### PR DESCRIPTION
The file name of sota has been changed in AGL, so change it to apply.

Signed-off-by: Minori Yasumura <minori@witz-inc.co.jp>