### PR TITLE
Update aktualizr recipe to use new .so names

### DIFF
--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -15,7 +15,7 @@ RDEPENDS_${PN}-ptest += "bash cmake curl net-tools python3-core python3-misc pyt
 PV = "1.0+git${SRCPV}"
 PR = "7"
 
-GARAGE_SIGN_PV = "0.7.0-66-g94f52d1"
+GARAGE_SIGN_PV = "0.7.0-68-g13c41f1"
 
 SRC_URI = " \
   gitsm://github.com/advancedtelematic/aktualizr;branch=${BRANCH};name=aktualizr \
@@ -27,10 +27,10 @@ SRC_URI = " \
   ${@ d.expand("https://ats-tuf-cli-releases.s3-eu-central-1.amazonaws.com/cli-${GARAGE_SIGN_PV}.tgz;unpack=0;name=garagesign") if d.getVar('GARAGE_SIGN_AUTOVERSION') != '1' else ''} \
   "
 
-SRC_URI[garagesign.md5sum] = "a7e17be337df92764a8e4bcbbbeff945"
-SRC_URI[garagesign.sha256sum] = "6c5136c8a769495175cf5daaebdfcd64985cca8ae829bb12ef5b92cf9af427c8"
+SRC_URI[garagesign.md5sum] = "c7c43904f39a6e4d91f1ddd196dcca3a"
+SRC_URI[garagesign.sha256sum] = "946a7401782ee326b458e0e7c668174d628dbf1354fc747a97d46e03f92663aa"
 
-SRCREV = "56ac8dafb552b1d15638162ca14e0b818ed5e65f"
+SRCREV = "be85b3a1454d79d926bcf066549a5ec530e67778"
 BRANCH ?= "master"
 
 S = "${WORKDIR}/git"
@@ -151,7 +151,7 @@ FILES_${PN} = " \
                 "
 
 FILES_${PN}-lib = " \
-                ${libdir}/libaktualizr_lib.so \
+                ${libdir}/libaktualizr.so \
                 "
 
 FILES_${PN}-resource-control = " \
@@ -170,11 +170,11 @@ FILES_${PN}-secondary = " \
                 "
 
 FILES_${PN}-secondary-lib = " \
-                ${libdir}/libaktualizr_secondary_lib.so \
+                ${libdir}/libaktualizr_secondary.so \
                 "
 
 FILES_${PN}-sotatools-lib = " \
-                ${libdir}/libsota_tools_lib.so \
+                ${libdir}/libsota_tools.so \
                 "
 
 FILES_${PN}-dev = ""


### PR DESCRIPTION
Aktualizr and garage-sign are also bumped in the process.