### PR TITLE
Fix/boost ptest

### DIFF
--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -86,9 +86,6 @@ do_install_ptest() {
     cp -r ${B}/ ${D}/${PTEST_PATH}/build
     cp -r ${S}/ ${D}/${PTEST_PATH}/src
 
-    # remove huge external unused repository
-    rm -rf ${D}/${PTEST_PATH}/src/partial/extern/RIOT
-
     # remove huge build artifacts
     find ${D}/${PTEST_PATH}/build/src -name "*.a" -delete
 

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -12,6 +12,8 @@ RDEPENDS_${PN}-host-tools = "aktualizr aktualizr-cert-provider ${@bb.utils.conta
 
 RDEPENDS_${PN}-ptest += "bash cmake curl net-tools python3-core python3-misc python3-modules openssl-bin sqlite3 valgrind"
 
+PRIVATE_LIBS_${PN}-ptest = "libaktualizr.so libaktualizr_secondary.so"
+
 PV = "1.0+git${SRCPV}"
 PR = "7"
 

--- a/recipes-support/boost/boost_1.72.0.bbappend
+++ b/recipes-support/boost/boost_1.72.0.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://0001-add-typedef-executor_type.patch \
+           "

--- a/recipes-support/boost/files/0001-add-typedef-executor_type.patch
+++ b/recipes-support/boost/files/0001-add-typedef-executor_type.patch
@@ -1,0 +1,56 @@
+From 99ad3ebac0b7466d57c98fb9583fbe8789729691 Mon Sep 17 00:00:00 2001
+From: Patrick Vacek <patrickvacek@gmail.com>
+Date: Wed, 4 Mar 2020 12:41:02 +0000
+Subject: [PATCH] add typedef executor_type
+
+Backported from here:
+https://github.com/boostorg/process/commit/6a4d2ff72114ef47c7afaf92e1042aca3dfa41b0
+
+Suggested-by: Kostiantyn Bushko <kbushko@intellias.com>
+Signed-off-by: Patrick Vacek <patrickvacek@gmail.com>
+---
+ boost/process/async_pipe.hpp                | 2 ++
+ boost/process/detail/posix/async_pipe.hpp   | 1 +
+ boost/process/detail/windows/async_pipe.hpp | 1 +
+ 3 files changed, 4 insertions(+)
+
+diff --git a/boost/process/async_pipe.hpp b/boost/process/async_pipe.hpp
+index 101fe1d..a562432 100644
+--- a/boost/process/async_pipe.hpp
++++ b/boost/process/async_pipe.hpp
+@@ -47,6 +47,8 @@ public:
+      */
+     typedef platform_specific handle_type;
+ 
++    typedef typename handle_type::executor_type executor_type;
++
+     /** Construct a new async_pipe, does automatically open the pipe.
+      * Initializes source and sink with the same io_context.
+      * @note Windows creates a named pipe here, where the name is automatically generated.
+diff --git a/boost/process/detail/posix/async_pipe.hpp b/boost/process/detail/posix/async_pipe.hpp
+index 725a078..a82c057 100644
+--- a/boost/process/detail/posix/async_pipe.hpp
++++ b/boost/process/detail/posix/async_pipe.hpp
+@@ -23,6 +23,7 @@ class async_pipe
+ public:
+     typedef int native_handle_type;
+     typedef ::boost::asio::posix::stream_descriptor handle_type;
++    typedef typename handle_type::executor_type executor_type;
+ 
+     inline async_pipe(boost::asio::io_context & ios) : async_pipe(ios, ios) {}
+ 
+diff --git a/boost/process/detail/windows/async_pipe.hpp b/boost/process/detail/windows/async_pipe.hpp
+index 06d5f2d..0b447f9 100644
+--- a/boost/process/detail/windows/async_pipe.hpp
++++ b/boost/process/detail/windows/async_pipe.hpp
+@@ -48,6 +48,7 @@ class async_pipe
+ public:
+     typedef ::boost::winapi::HANDLE_ native_handle_type;
+     typedef ::boost::asio::windows::stream_handle   handle_type;
++    typedef typename handle_type::executor_type executor_type;
+ 
+     async_pipe(boost::asio::io_context & ios) : async_pipe(ios, ios, make_pipe_name(), true) {}
+     async_pipe(boost::asio::io_context & ios_source, boost::asio::io_context & ios_sink)
+-- 
+2.11.0
+


### PR DESCRIPTION
I believe this fixes the failures we've been seeing in ptest for months now. (See for example [here](https://main.gitlab.in.here.com/olp/edge/ota/connect/client/meta-updater/-/jobs/1767502).) However, this appears to have uncovered a [new issue](https://main.gitlab.in.here.com/olp/edge/ota/connect/client/meta-updater/-/jobs/1826961) with errors like these:

```
ERROR: aktualizr-1.0+gitAUTOINC+9f2cc5d7b0-7 do_package: aktualizr-secondary: Multiple shlib providers for libaktualizr_secondary.so: aktualizr-secondary-lib, aktualizr-ptest (used by files: /builds/olp/edge/ota/connect/client/meta-updater/build-oe-qemux86_64-ptest-st/tmp/work/core2-64-poky-linux/aktualizr/1.0+gitAUTOINC+9f2cc5d7b0-7/packages-split/aktualizr-secondary/usr/bin/aktualizr-secondary)
ERROR: aktualizr-1.0+gitAUTOINC+9f2cc5d7b0-7 do_package: aktualizr-ptest: Multiple shlib providers for libaktualizr.so: aktualizr-lib, aktualizr-ptest (used by files: /builds/olp/edge/ota/connect/client/meta-updater/build-oe-qemux86_64-ptest-st/tmp/work/core2-64-poky-linux/aktualizr/1.0+gitAUTOINC+9f2cc5d7b0-7/packages-split/aktualizr-ptest/usr/lib/aktualizr/ptest/build/src/libaktualizr/http/t_http_client)
```

and these:

```
ERROR: aktualizr-1.0+gitAUTOINC+9f2cc5d7b0-7 do_package: aktualizr: Multiple shlib providers for libaktualizr.so: aktualizr-lib, aktualizr-ptest (used by files: /builds/olp/edge/ota/connect/client/meta-updater/build-oe-qemux86_64-ptest-st/tmp/work/core2-64-poky-linux/aktualizr/1.0+gitAUTOINC+9f2cc5d7b0-7/packages-split/aktualizr/usr/bin/aktualizr)
ERROR: aktualizr-1.0+gitAUTOINC+9f2cc5d7b0-7 do_package: aktualizr: Multiple shlib providers for libaktualizr.so: aktualizr-lib, aktualizr-ptest (used by files: /builds/olp/edge/ota/connect/client/meta-updater/build-oe-qemux86_64-ptest-st/tmp/work/core2-64-poky-linux/aktualizr/1.0+gitAUTOINC+9f2cc5d7b0-7/packages-split/aktualizr/usr/bin/aktualizr-info)
ERROR: aktualizr-1.0+gitAUTOINC+9f2cc5d7b0-7 do_package: aktualizr-get: Multiple shlib providers for libaktualizr.so: aktualizr-lib, aktualizr-ptest (used by files: /builds/olp/edge/ota/connect/client/meta-updater/build-oe-qemux86_64-ptest-st/tmp/work/core2-64-poky-linux/aktualizr/1.0+gitAUTOINC+9f2cc5d7b0-7/packages-split/aktualizr-get/usr/bin/aktualizr-get)
ERROR: aktualizr-1.0+gitAUTOINC+9f2cc5d7b0-7 do_package: aktualizr-lite: Multiple shlib providers for libaktualizr.so: aktualizr-lib, aktualizr-ptest (used by files: /builds/olp/edge/ota/connect/client/meta-updater/build-oe-qemux86_64-ptest-st/tmp/work/core2-64-poky-linux/aktualizr/1.0+gitAUTOINC+9f2cc5d7b0-7/packages-split/aktualizr-lite/usr/bin/aktualizr-lite)
ERROR: aktualizr-1.0+gitAUTOINC+9f2cc5d7b0-7 do_package: uptane-generator: Multiple shlib providers for libaktualizr.so: aktualizr-lib, aktualizr-ptest (used by files: /builds/olp/edge/ota/connect/client/meta-updater/build-oe-qemux86_64-ptest-st/tmp/work/core2-64-poky-linux/aktualizr/1.0+gitAUTOINC+9f2cc5d7b0-7/packages-split/uptane-generator/usr/bin/uptane-generator)
```

But this is at least progress.