### PR TITLE
aktualizr: fix a dependency QA warning

### DIFF
--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -60,7 +60,7 @@ PACKAGECONFIG[hsm] = "-DBUILD_P11=ON -DPKCS11_ENGINE_PATH=${PKCS11_ENGINE_PATH},
 PACKAGECONFIG[sota-tools] = "-DBUILD_SOTA_TOOLS=ON ${GARAGE_SIGN_OPS},-DBUILD_SOTA_TOOLS=OFF,glib-2.0,"
 PACKAGECONFIG[load-tests] = "-DBUILD_LOAD_TESTS=ON,-DBUILD_LOAD_TESTS=OFF,"
 PACKAGECONFIG[serialcan] = ",,,slcand-start"
-PACKAGECONFIG[ubootenv] = ",,,u-boot-fw-utils aktualizr-uboot-env-rollback"
+PACKAGECONFIG[ubootenv] = ",,u-boot-fw-utils,u-boot-fw-utils aktualizr-uboot-env-rollback"
 
 # can be overriden in configuration with `RESOURCE_xxx_pn-aktualizr`
 # see `man systemd.resource-control` for details


### PR DESCRIPTION
This fixes a following QA warning:
| WARNING: aktualizr do_package_qa: QA Issue: aktualizr rdepends on
| u-boot-fw-utils, but it isn't a build dependency, missing
| u-boot-fw-utils in DEPENDS or PACKAGECONFIG? [build-deps]

Signed-off-by: Ming Liu <ming.liu@toradex.com>