### PR TITLE
Use checksum as deployment source and refspec in the deployment

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -168,25 +168,19 @@ IMAGE_CMD_ostreecommit () {
     fi
 
     # Commit the result
-    ostree --repo=${OSTREE_REPO} commit \
+    ostree_target_hash=$(ostree --repo=${OSTREE_REPO} commit \
            --tree=dir=${OSTREE_ROOTFS} \
            --skip-if-unchanged \
            --branch=${OSTREE_BRANCHNAME} \
            --subject="${OSTREE_COMMIT_SUBJECT}" \
            --body="${OSTREE_COMMIT_BODY}" \
-           --add-metadata-string=version="${OSTREE_COMMIT_VERSION}" \
-           --bind-ref="${OSTREE_BRANCHNAME}-${IMAGE_BASENAME}"
+           --add-metadata-string=version="${OSTREE_COMMIT_VERSION}")
+
+    echo $ostree_target_hash > ${WORKDIR}/ostree_manifest
 
     if [ "${OSTREE_UPDATE_SUMMARY}" = "1" ]; then
         ostree --repo=${OSTREE_REPO} summary -u
     fi
-
-    # To enable simultaneous bitbaking of two images with the same branch name,
-    # create a new ref in the repo using the basename of the image. (This first
-    # requires deleting it if it already exists.) Fixes OTA-2211.
-    ostree --repo=${OSTREE_REPO} refs --delete ${OSTREE_BRANCHNAME}-${IMAGE_BASENAME}
-    ostree_target_hash=$(cat ${OSTREE_REPO}/refs/heads/${OSTREE_BRANCHNAME})
-    ostree --repo=${OSTREE_REPO} refs --create=${OSTREE_BRANCHNAME}-${IMAGE_BASENAME} ${ostree_target_hash}
 }
 
 IMAGE_TYPEDEP_ostreepush = "ostreecommit"
@@ -236,7 +230,7 @@ IMAGE_CMD_garagesign () {
                          --home-dir ${GARAGE_SIGN_REPO} \
                          --credentials ${SOTA_PACKED_CREDENTIALS}
 
-        ostree_target_hash=$(cat ${OSTREE_REPO}/refs/heads/${OSTREE_BRANCHNAME}-${IMAGE_BASENAME})
+        ostree_target_hash=$(cat ${WORKDIR}/ostree_manifest)
 
         # Use OSTree target hash as version if none was provided by the user
         target_version=${ostree_target_hash}
@@ -312,7 +306,7 @@ IMAGE_CMD_garagecheck () {
         # if credentials are issued by a server that doesn't support offline signing, exit silently
         unzip -p ${SOTA_PACKED_CREDENTIALS} root.json targets.pub targets.sec tufrepo.url 2>&1 >/dev/null || exit 0
 
-        ostree_target_hash=$(cat ${OSTREE_REPO}/refs/heads/${OSTREE_BRANCHNAME}-${IMAGE_BASENAME})
+        ostree_target_hash=$(cat ${WORKDIR}/ostree_manifest)
 
         garage-check --ref=${ostree_target_hash} \
                      --credentials=${SOTA_PACKED_CREDENTIALS} \

--- a/classes/image_types_ota.bbclass
+++ b/classes/image_types_ota.bbclass
@@ -64,7 +64,7 @@ IMAGE_CMD_ota () {
 		bbfatal "Invalid bootloader: ${OSTREE_BOOTLOADER}"
 	fi
 
-	ostree_target_hash=$(cat ${OSTREE_REPO}/refs/heads/${OSTREE_BRANCHNAME}-${IMAGE_BASENAME})
+	ostree_target_hash=$(cat ${WORKDIR}/ostree_manifest)
 
 	ostree --repo=${OTA_SYSROOT}/ostree/repo pull-local --remote=${OSTREE_OSNAME} ${OSTREE_REPO} ${ostree_target_hash}
 	kargs_list=""


### PR DESCRIPTION
This merge request uses the OSTree commit checksum as source reference in the OSTree deployment task `do_image_ota`. This guarantees that the exact commit this build commited in `do_image_ostreecommit` actually gets deployed.

It also makes sure that `origin refspec` appears in `ostree admin status`, and hence will be used when using `ostree admin upgrade`. This is similar to what #687 tries to achieve.