### PR TITLE
meta: change virtual/network-configuration to network-configuration

### DIFF
--- a/classes/sota_m3ulcb.bbclass
+++ b/classes/sota_m3ulcb.bbclass
@@ -8,5 +8,5 @@ OSTREE_BOOTLOADER ?= "u-boot"
 
 UBOOT_MACHINE_sota = "${@d.getVar('SOC_FAMILY').split(':')[1]}_ulcb_defconfig"
 
-PREFERRED_RPROVIDER_virtual/network-configuration ?= "connman"
-IMAGE_INSTALL_append_sota = " virtual/network-configuration "
+PREFERRED_RPROVIDER_network-configuration ?= "connman"
+IMAGE_INSTALL_append_sota = " network-configuration "

--- a/classes/sota_minnowboard.bbclass
+++ b/classes/sota_minnowboard.bbclass
@@ -8,5 +8,5 @@ IMAGE_FSTYPES_remove_sota = "live hddimg"
 OSTREE_KERNEL_ARGS ?= "ramdisk_size=16384 rw rootfstype=ext4 rootwait rootdelay=2 console=ttyS0,115200 console=tty0"
 IMAGE_INSTALL_append = " minnowboard-efi-startup"
 
-PREFERRED_RPROVIDER_virtual/network-configuration ?= "connman"
-IMAGE_INSTALL_append_sota = " virtual/network-configuration "
+PREFERRED_RPROVIDER_network-configuration ?= "connman"
+IMAGE_INSTALL_append_sota = " network-configuration "

--- a/classes/sota_porter.bbclass
+++ b/classes/sota_porter.bbclass
@@ -7,5 +7,5 @@ IMAGE_BOOT_FILES_sota += "porter-bootfiles/*"
 OSTREE_BOOTLOADER ?= "u-boot"
 UBOOT_MACHINE_sota = "porter_config"
 
-PREFERRED_RPROVIDER_virtual/network-configuration ?= "connman"
-IMAGE_INSTALL_append_sota = " virtual/network-configuration "
+PREFERRED_RPROVIDER_network-configuration ?= "connman"
+IMAGE_INSTALL_append_sota = " network-configuration "

--- a/classes/sota_qemux86-64.bbclass
+++ b/classes/sota_qemux86-64.bbclass
@@ -13,4 +13,4 @@ IMAGE_ROOTFS_EXTRA_SPACE = "${@bb.utils.contains('DISTRO_FEATURES', 'sota', '655
 # fix for u-boot/swig build issue
 HOSTTOOLS_NONFATAL += "x86_64-linux-gnu-gcc"
 
-IMAGE_INSTALL_append_sota = " virtual/network-configuration "
+IMAGE_INSTALL_append_sota = " network-configuration "

--- a/classes/sota_raspberrypi.bbclass
+++ b/classes/sota_raspberrypi.bbclass
@@ -13,7 +13,7 @@ UBOOT_DTBO_LOADADDRESS = "0x06000000"
 IMAGE_INSTALL_append = " fit-conf"
 
 DEV_MATCH_DIRECTIVE_pn-networkd-dhcp-conf = "Driver=smsc95xx lan78xx"
-IMAGE_INSTALL_append_sota = " virtual/network-configuration "
+IMAGE_INSTALL_append_sota = " network-configuration "
 
 PREFERRED_PROVIDER_virtual/bootloader_sota ?= "u-boot"
 UBOOT_ENTRYPOINT_sota ?= "0x00080000"

--- a/conf/distro/poky-sota-systemd.conf
+++ b/conf/distro/poky-sota-systemd.conf
@@ -9,4 +9,4 @@ DISTRO_CODENAME = "sota"
 
 DISTRO_FEATURES_append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"
-PREFERRED_RPROVIDER_virtual/network-configuration ??= "networkd-dhcp-conf"
+PREFERRED_RPROVIDER_network-configuration ??= "networkd-dhcp-conf"

--- a/conf/local.conf.nonostree.append
+++ b/conf/local.conf.nonostree.append
@@ -2,7 +2,7 @@
 DISTRO_FEATURES_append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 
-PREFERRED_RPROVIDER_virtual/network-configuration ??= "networkd-dhcp-conf"
+PREFERRED_RPROVIDER_network-configuration ??= "networkd-dhcp-conf"
 
 SOTA_DEPLOY_CREDENTIALS ?= "1"
 PACKAGECONFIG_pn-aktualizr = ""

--- a/lib/oeqa/selftest/cases/updater_qemux86_64.py
+++ b/lib/oeqa/selftest/cases/updater_qemux86_64.py
@@ -130,7 +130,7 @@ class SharedCredProvTestsNonOSTree(SharedCredProvTests):
         self.append_config('DISTRO = "poky"')
         self.append_config('DISTRO_FEATURES_append = " systemd"')
         self.append_config('VIRTUAL-RUNTIME_init_manager = "systemd"')
-        self.append_config('PREFERRED_RPROVIDER_virtual/network-configuration ??= "networkd-dhcp-conf"')
+        self.append_config('PREFERRED_RPROVIDER_network-configuration ??= "networkd-dhcp-conf"')
         self.append_config('PACKAGECONFIG_pn-aktualizr = ""')
         self.append_config('SOTA_DEPLOY_CREDENTIALS = "1"')
         self.append_config('IMAGE_INSTALL_append += "aktualizr"')

--- a/recipes-connectivity/connman/connman_%.bbappend
+++ b/recipes-connectivity/connman/connman_%.bbappend
@@ -1,1 +1,1 @@
-RPROVIDES_${PN} += "virtual/network-configuration"
+RPROVIDES_${PN} += "network-configuration"

--- a/recipes-connectivity/networkd-dhcp-conf/networkd-dhcp-conf.bb
+++ b/recipes-connectivity/networkd-dhcp-conf/networkd-dhcp-conf.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7
 
 inherit systemd
 
-RPROVIDES_${PN} = "virtual/network-configuration"
+RPROVIDES_${PN} = "network-configuration"
 
 SRC_URI = " \
   file://20-wired-dhcp.network \

--- a/recipes-test/images/primary-image.bb
+++ b/recipes-test/images/primary-image.bb
@@ -5,7 +5,7 @@ SUMMARY = "A minimal Uptane Primary image running aktualizr, for testing with a 
 LICENSE = "MPL-2.0"
 
 IMAGE_INSTALL_remove = " \
-			virtual/network-configuration \
+			network-configuration \
                         "
 
 IMAGE_INSTALL_append = " \

--- a/recipes-test/images/secondary-image.bb
+++ b/recipes-test/images/secondary-image.bb
@@ -16,7 +16,7 @@ IMAGE_INSTALL_remove = " \
                         aktualizr-device-prov \
                         aktualizr-device-prov-hsm \
                         aktualizr-uboot-env-rollback \
-                        virtual/network-configuration \
+                        network-configuration \
                         "
 
 IMAGE_INSTALL_append = " \


### PR DESCRIPTION
The name 'virtual' is a recipe specific concept but not a package
specific one, it's confusing that a package provides 'virtual/' names.

Let's drop 'virtual/' from network-configuration, to keep consistent
with yocto naming styles.

Signed-off-by: Ming Liu <ming.liu@toradex.com>