### PR TITLE
initramfs-ostree-image: drop qemuboot from IMAGE_CLASSES

### DIFF
--- a/recipes-core/images/initramfs-ostree-image.bb
+++ b/recipes-core/images/initramfs-ostree-image.bb
@@ -13,7 +13,7 @@ IMAGE_LINGUAS = ""
 
 LICENSE = "MIT"
 
-IMAGE_CLASSES_remove = "image_repo_manifest"
+IMAGE_CLASSES_remove = "image_repo_manifest qemuboot"
 
 IMAGE_FSTYPES = "${INITRAMFS_FSTYPES}"
 


### PR DESCRIPTION
To avoid generating a qemuboot.conf for qemu machines, it's useless for
a initramfs image.

Signed-off-by: Ming Liu <ming.liu@toradex.com>