### PR TITLE
sota_sanity.bbclass: introduce sota_check_boolean_variable

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -141,7 +141,7 @@ IMAGE_CMD_ostree () {
         checksum=$(sha256sum ${DEPLOY_DIR_IMAGE}/${OSTREE_KERNEL} | cut -f 1 -d " ")
         touch boot/initramfs-${checksum}
     else
-        if [ "${OSTREE_DEPLOY_DEVICETREE}" = "1"  ] && [ -n "${KERNEL_DEVICETREE}" ]; then
+        if [ ${@ oe.types.boolean('${OSTREE_DEPLOY_DEVICETREE}')} = True ] && [ -n "${KERNEL_DEVICETREE}" ]; then
             checksum=$(cat ${DEPLOY_DIR_IMAGE}/${OSTREE_KERNEL} ${DEPLOY_DIR_IMAGE}/${INITRAMFS_IMAGE}-${MACHINE}.${INITRAMFS_FSTYPES} ${KERNEL_DEVICETREE} | sha256sum | cut -f 1 -d " ")
             for DTS_FILE in ${KERNEL_DEVICETREE}; do
                 DTS_FILE_BASENAME=$(basename ${DTS_FILE})
@@ -177,7 +177,7 @@ IMAGE_CMD_ostreecommit () {
            --add-metadata-string=version="${OSTREE_COMMIT_VERSION}" \
            --bind-ref="${OSTREE_BRANCHNAME}-${IMAGE_BASENAME}"
 
-    if [ "${OSTREE_UPDATE_SUMMARY}" = "1" ]; then
+    if [ ${@ oe.types.boolean('${OSTREE_UPDATE_SUMMARY}')} = True ]; then
         ostree --repo=${OSTREE_REPO} summary -u
     fi
 

--- a/classes/sota_sanity.bbclass
+++ b/classes/sota_sanity.bbclass
@@ -1,5 +1,12 @@
 # Sanity check the sota setup for common misconfigurations
 
+def sota_check_boolean_variable(var, d):
+    try:
+        oe.types.boolean(d.getVar(var))
+    except:
+        return False
+    return True
+
 def sota_check_overrides(status, d):
     for var in (d.getVar('SOTA_OVERRIDES_BLACKLIST') or "").split():
         if var in d.getVar('OVERRIDES').split(':'):
@@ -47,14 +54,14 @@ def sota_check_variables_validity(status, d):
         path = os.path.abspath(credentials)
         if not os.path.exists(path):
             status.addresult("SOTA_PACKED_CREDENTIALS is not set correctly. The zipped credentials file does not exist.\n")
-    if d.getVar("OSTREE_UPDATE_SUMMARY") and d.getVar("OSTREE_UPDATE_SUMMARY") not in ("0", "1", ""):
-        status.addresult("OSTREE_UPDATE_SUMMARY should be set to 0 or 1.\n")
-    if d.getVar("OSTREE_DEPLOY_DEVICETREE") and d.getVar("OSTREE_DEPLOY_DEVICETREE") not in ("0", "1", ""):
-        status.addresult("OSTREE_DEPLOY_DEVICETREE should be set to 0 or 1.\n")
-    if d.getVar("GARAGE_SIGN_AUTOVERSION") and d.getVar("GARAGE_SIGN_AUTOVERSION") not in ("0", "1", ""):
-        status.addresult("GARAGE_SIGN_AUTOVERSION should be set to 0 or 1.\n")
-    if d.getVar("SOTA_DEPLOY_CREDENTIALS") and d.getVar("SOTA_DEPLOY_CREDENTIALS") not in ("0", "1", ""):
-        status.addresult("SOTA_DEPLOY_CREDENTIALS should be set to 0 or 1.\n")
+    if not sota_check_boolean_variable("OSTREE_UPDATE_SUMMARY", d):
+        status.addresult("OSTREE_UPDATE_SUMMARY (=%s) should be set to yes/y/true/t/1 or no/n/false/f/0.\n" % d.getVar("OSTREE_UPDATE_SUMMARY"))
+    if not sota_check_boolean_variable("OSTREE_DEPLOY_DEVICETREE", d):
+        status.addresult("OSTREE_DEPLOY_DEVICETREE (=%s) should be set to yes/y/true/t/1 or no/n/false/f/0.\n" % d.getVar("OSTREE_DEPLOY_DEVICETREE"))
+    if not sota_check_boolean_variable("GARAGE_SIGN_AUTOVERSION", d):
+        status.addresult("GARAGE_SIGN_AUTOVERSION (=%s) should be set to yes/y/true/t/1 or no/n/false/f/0.\n" % d.getVar("GARAGE_SIGN_AUTOVERSION"))
+    if not sota_check_boolean_variable("SOTA_DEPLOY_CREDENTIALS", d):
+        status.addresult("SOTA_DEPLOY_CREDENTIALS (=%s) should be set to yes/y/true/t/1 or no/n/false/f/0.\n" % d.getVar("SOTA_DEPLOY_CREDENTIALS"))
     
 def sota_raise_sanity_error(msg, d):
     if d.getVar("SANITY_USE_EVENTS") == "1":

--- a/recipes-sota/aktualizr/aktualizr-shared-prov.bb
+++ b/recipes-sota/aktualizr/aktualizr-shared-prov.bb
@@ -10,7 +10,7 @@ inherit allarch
 # We need to get the config files from the aktualizr-host-tools package built by
 # the aktualizr (target) recipe.
 DEPENDS = "aktualizr"
-RDEPENDS_${PN}_append = "${@' aktualizr-shared-prov-creds' if d.getVar('SOTA_DEPLOY_CREDENTIALS') == '1' else ''}"
+RDEPENDS_${PN}_append = "${@' aktualizr-shared-prov-creds' if oe.types.boolean(d.getVar('SOTA_DEPLOY_CREDENTIALS')) else ''}"
 
 # If the config file from aktualizr used here is changed, you will need to bump
 # the version here because of SIGGEN_EXCLUDE_SAFE_RECIPE_DEPS!

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -26,7 +26,7 @@ SRC_URI = " \
   file://aktualizr-secondary.service \
   file://aktualizr-serialcan.service \
   file://10-resource-control.conf \
-  ${@ d.expand("https://tuf-cli-releases.ota.here.com/cli-${GARAGE_SIGN_PV}.tgz;unpack=0;name=garagesign") if d.getVar('GARAGE_SIGN_AUTOVERSION') != '1' else ''} \
+  ${@ d.expand("https://tuf-cli-releases.ota.here.com/cli-${GARAGE_SIGN_PV}.tgz;unpack=0;name=garagesign") if not oe.types.boolean(d.getVar('GARAGE_SIGN_AUTOVERSION')) else ''} \
   "
 
 SRC_URI[garagesign.md5sum] = "febc186527b324b23c5be3affcf90e54"
@@ -49,7 +49,7 @@ SYSTEMD_SERVICE_${PN}-secondary = "aktualizr-secondary.service"
 
 EXTRA_OECMAKE = "-DCMAKE_BUILD_TYPE=Release ${@bb.utils.contains('PTEST_ENABLED', '1', '-DTESTSUITE_VALGRIND=on', '', d)}"
 
-GARAGE_SIGN_OPS = "${@ d.expand('-DGARAGE_SIGN_ARCHIVE=${WORKDIR}/cli-${GARAGE_SIGN_PV}.tgz') if d.getVar('GARAGE_SIGN_AUTOVERSION') != '1' else ''}"
+GARAGE_SIGN_OPS = "${@ d.expand('-DGARAGE_SIGN_ARCHIVE=${WORKDIR}/cli-${GARAGE_SIGN_PV}.tgz') if not oe.types.boolean(d.getVar('GARAGE_SIGN_AUTOVERSION')) else ''}"
 PKCS11_ENGINE_PATH = "${libdir}/engines-1.1/pkcs11.so"
 
 PACKAGECONFIG ?= "ostree ${@bb.utils.filter('SOTA_CLIENT_FEATURES', 'hsm serialcan ubootenv', d)}"


### PR DESCRIPTION
The current sanity check are too strict for some boolean variables,
introduce sota_check_boolean_variable to allow a boolean value to be
set like yes/y/true/t/1 or no/n/false/f/0.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>