### PR TITLE
Adding collectd configuration for aktualizr

### DIFF
--- a/recipes-extended/collectd/collectd_%.bbappend
+++ b/recipes-extended/collectd/collectd_%.bbappend
@@ -1,0 +1,5 @@
+do_install_append() {
+    printf "<Include \"${sysconfdir}/collectd.conf.d\">\nFilter \"*.conf\"\n</Include>\n" >> ${D}/${sysconfdir}/collectd.conf
+
+    install -d ${D}/${sysconfdir}/collectd.conf.d
+}

--- a/recipes-sota/aktualizr/aktualizr-collectd.bb
+++ b/recipes-sota/aktualizr/aktualizr-collectd.bb
@@ -1,0 +1,21 @@
+SUMMARY = "Aktualizr metric collection"
+HOMEPAGE = "https://github.com/advancedtelematic/aktualizr"
+SECTION = "base"
+LICENSE = "MPL-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
+
+RDEPENDS_${PN} = "collectd"
+
+SRC_URI = " file://aktualizr-collectd.conf"
+
+S = "${WORKDIR}"
+
+do_install() {
+    install -d ${D}${sysconfdir}/collectd.conf.d
+    install -m 0644 ${WORKDIR}/aktualizr-collectd.conf ${D}${sysconfdir}/collectd.conf.d/aktualizr.conf
+}
+
+FILES_${PN} = " \
+                ${sysconfdir}/collectd.conf.d \
+                ${sysconfdir}/collectd.conf.d/aktualizr.conf \
+                "

--- a/recipes-sota/aktualizr/files/aktualizr-collectd.conf
+++ b/recipes-sota/aktualizr/files/aktualizr-collectd.conf
@@ -1,0 +1,9 @@
+<LoadPlugin processes>
+	Interval 1
+</LoadPlugin>
+<Plugin processes>
+        CollectFileDescriptor true
+        CollectContextSwitch true
+        CollectMemoryMaps true
+        Process "aktualizr"
+</Plugin>


### PR DESCRIPTION
Collectd has already a lot of monitoring features we want out of the box.
Simple usage is to build with `IMAGE_INSTALL_append = " aktualizr-collectd"`, then stats can be retrieved with 

```
scp  root@localhost:'/var/lib/collectd/*/processes-aktualizr/ps_rss.rrd' .
```

And a simple graph of the last 10 minutes:

```
rrdtool graph /tmp/graph.png -a PNG --start end-10m --title="Aktualizr Memory" 'DEF:mem=ps_rss.rrd:value:AVERAGE' 'LINE1:mem#ff0000:Memory'
```