### PR TITLE
image_types_ostree: allow to add layer specific OSTree commit arguments

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -174,7 +174,8 @@ IMAGE_CMD_ostreecommit () {
            --branch=${OSTREE_BRANCHNAME} \
            --subject="${OSTREE_COMMIT_SUBJECT}" \
            --body="${OSTREE_COMMIT_BODY}" \
-           --add-metadata-string=version="${OSTREE_COMMIT_VERSION}")
+           --add-metadata-string=version="${OSTREE_COMMIT_VERSION}" \
+           ${EXTRA_OSTREE_COMMIT})
 
     echo $ostree_target_hash > ${WORKDIR}/ostree_manifest
 


### PR DESCRIPTION
The OSTree commit command allows to add metadata to the commit. This
might be customized in a distro layer for distribution specific needs.
Allow to pass extra arguments using EXTRA_OSTREE_COMMIT variable
(using a variable named similar to EXTRA_OEMAKE used to pass extra make
arguments).

Signed-off-by: Stefan Agner <stefan.agner@toradex.com>