### PR TITLE
image_types_ostree: allow specifying a device tree to deploy

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -10,6 +10,7 @@ OSTREE_COMMIT_BODY ??= ""
 OSTREE_COMMIT_VERSION ??= "${DISTRO_VERSION}"
 OSTREE_UPDATE_SUMMARY ??= "0"
 OSTREE_DEPLOY_DEVICETREE ??= "0"
+OSTREE_DEVICETREE ??= "${KERNEL_DEVICETREE}"
 
 BUILD_OSTREE_TARBALL ??= "1"
 
@@ -141,9 +142,9 @@ IMAGE_CMD_ostree () {
         checksum=$(sha256sum ${DEPLOY_DIR_IMAGE}/${OSTREE_KERNEL} | cut -f 1 -d " ")
         touch boot/initramfs-${checksum}
     else
-        if [ ${@ oe.types.boolean('${OSTREE_DEPLOY_DEVICETREE}')} = True ] && [ -n "${KERNEL_DEVICETREE}" ]; then
-            checksum=$(cat ${DEPLOY_DIR_IMAGE}/${OSTREE_KERNEL} ${DEPLOY_DIR_IMAGE}/${INITRAMFS_IMAGE}-${MACHINE}.${INITRAMFS_FSTYPES} ${KERNEL_DEVICETREE} | sha256sum | cut -f 1 -d " ")
-            for DTS_FILE in ${KERNEL_DEVICETREE}; do
+        if [ ${@ oe.types.boolean('${OSTREE_DEPLOY_DEVICETREE}')} = True ] && [ -n "${OSTREE_DEVICETREE}" ]; then
+            checksum=$(cat ${DEPLOY_DIR_IMAGE}/${OSTREE_KERNEL} ${DEPLOY_DIR_IMAGE}/${INITRAMFS_IMAGE}-${MACHINE}.${INITRAMFS_FSTYPES} ${OSTREE_DEVICETREE} | sha256sum | cut -f 1 -d " ")
+            for DTS_FILE in ${OSTREE_DEVICETREE}; do
                 DTS_FILE_BASENAME=$(basename ${DTS_FILE})
                 cp ${DEPLOY_DIR_IMAGE}/${DTS_FILE_BASENAME} boot/devicetree-${DTS_FILE_BASENAME}-${checksum}
             done


### PR DESCRIPTION
When setting `OSTREE_DEPLOY_DEVICETREE` to 1, it will by default deploy
all the device tree blobs present in `KERNEL_DEVICETREE`. Adding
`OSTREE_DEVICETREE` would allow specifying a specific device tree blob
(or several dtbs), thus resulting in only the specified ones in the
image. This is particularely useful because ostree selects the first
device tree it finds in /boot, and discards the remaining ones.