### PR TITLE
aktualizr: make use of boot-complete.target

### DIFF
--- a/recipes-sota/aktualizr/files/aktualizr.service
+++ b/recipes-sota/aktualizr/files/aktualizr.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Aktualizr SOTA Client
-After=network-online.target nss-lookup.target
+After=network-online.target nss-lookup.target boot-complete.target
+Requires=boot-complete.target
 Wants=network-online.target
 
 [Service]


### PR DESCRIPTION
From the systemd.special(7) man page section boot-complete.target:
This target is intended as generic synchronization point for services
that shall determine or act on whether the boot process completed
successfully.

Let's make use of the target. Since aktualizr by default marks a boot
as successful, we consider aktualizr.service a service which needs to
be executed on successful boot (hence after the boot-complete.target).

This allows to declare a service as crucial by simply ordering it before
the boot-complete.target. The systemd example service
systemd-boot-check-no-failures.service can serve as an example.

This change does not add any service dependency by default as
boot-complete.target by default does not has any extra dependencies.

Note that rebooting in the failure case is not handled by this
mechanism. This can be added by using FailureAction.

Boot assessement infrastructure got introduced with systemd 240. See
also:
https://systemd.io/AUTOMATIC_BOOT_ASSESSMENT/

Signed-off-by: Stefan Agner <stefan.agner@toradex.com>