### PR TITLE
Put aktualizr-info in a separate package and use it in Secondaries.

### DIFF
--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -1,12 +1,11 @@
 DISTROOVERRIDES .= "${@bb.utils.contains('DISTRO_FEATURES', 'sota', ':sota', '', d)}"
 
-SOTA_CLIENT ??= "aktualizr"
 SOTA_CLIENT_PROV ??= "aktualizr-shared-prov"
 SOTA_DEPLOY_CREDENTIALS ?= "1"
 SOTA_HARDWARE_ID ??= "${MACHINE}"
 
 IMAGE_CLASSES += " image_types_ostree image_types_ota image_repo_manifest"
-IMAGE_INSTALL_append_sota = " ${SOTA_CLIENT} ${SOTA_CLIENT_PROV} \
+IMAGE_INSTALL_append_sota = " aktualizr aktualizr-info ${SOTA_CLIENT_PROV} \
                               ostree os-release ostree-kernel \
                               ${@'ostree-initramfs' if d.getVar('KERNEL_IMAGETYPE') != 'fitImage' else ''} \
                               ${@'ostree-devicetrees' if oe.types.boolean('${OSTREE_DEPLOY_DEVICETREE}') else ''}"

--- a/lib/oeqa/selftest/cases/updater_qemux86_64.py
+++ b/lib/oeqa/selftest/cases/updater_qemux86_64.py
@@ -133,8 +133,7 @@ class SharedCredProvTestsNonOSTree(SharedCredProvTests):
         self.append_config('PREFERRED_RPROVIDER_network-configuration ??= "networkd-dhcp-conf"')
         self.append_config('PACKAGECONFIG_pn-aktualizr = ""')
         self.append_config('SOTA_DEPLOY_CREDENTIALS = "1"')
-        self.append_config('IMAGE_INSTALL_append += "aktualizr"')
-        self.append_config('IMAGE_INSTALL_append += " aktualizr-shared-prov"')
+        self.append_config('IMAGE_INSTALL_append += "aktualizr aktualizr-info aktualizr-shared-prov"')
         self.qemu, self.s = qemu_launch(machine='qemux86-64', uboot_enable='no')
 
 

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -132,21 +132,23 @@ PACKAGESPLITFUNCS_prepend = "split_hosttools_packages "
 python split_hosttools_packages () {
     bindir = d.getVar('bindir')
 
-    # Split all binaries to their own packages except aktualizr-info,
-    # aktualizr-info should stay in main package aktualizr.
-    do_split_packages(d, bindir, r'^((?!(aktualizr-info)).*)$', '%s', 'Aktualizr tool - %s', extra_depends='aktualizr-configs', prepend=False)
+    # Split all binaries to their own packages.
+    do_split_packages(d, bindir, '^(.*)$', '%s', 'Aktualizr tool - %s', extra_depends='aktualizr-configs', prepend=False)
 }
 
 PACKAGES_DYNAMIC = "^aktualizr-.* ^garage-.*"
 
-PACKAGES =+ "${PN}-host-tools ${PN}-lib ${PN}-resource-control ${PN}-configs ${PN}-secondary ${PN}-secondary-lib ${PN}-sotatools-lib"
+PACKAGES =+ "${PN}-host-tools ${PN}-info ${PN}-lib ${PN}-resource-control ${PN}-configs ${PN}-secondary ${PN}-secondary-lib ${PN}-sotatools-lib"
 
 ALLOW_EMPTY_${PN}-host-tools = "1"
 
 FILES_${PN} = " \
                 ${bindir}/aktualizr \
-                ${bindir}/aktualizr-info \
                 ${systemd_unitdir}/system/aktualizr.service \
+                "
+
+FILES_${PN}-info = " \
+                ${bindir}/aktualizr-info \
                 "
 
 FILES_${PN}-lib = " \


### PR DESCRIPTION
We did the work a while ago to make aktualizr-info work for Secondaries,
but until now we weren't putting the tool into the secondary-image we
use for testing. Now it's there. Actually, it's in every image that
inherits from sota.bbclass, which is probably a good thing.