### PR TITLE
ostree-kernel-initramfs: fix parsing for MACHINEs which don't define …

### DIFF
--- a/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_0.0.1.bb
+++ b/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_0.0.1.bb
@@ -49,4 +49,5 @@ do_install() {
     fi
 }
 do_install[vardepsexclude] = "KERNEL_VERSION"
+INITRAMFS_IMAGE ?= ""
 do_install[depends] = "virtual/kernel:do_deploy ${@['${INITRAMFS_IMAGE}:do_image_complete', ''][d.getVar('INITRAMFS_IMAGE') == '']}"


### PR DESCRIPTION
…INITRAMFS_IMAGE

* when INITRAMFS_IMAGE isn't defined at all, the "d.getVar('INITRAMFS_IMAGE') == ''" part
  doesn't do anything useful, because the unexpanded version of this ends in
  do_install[depends] variable and breaks parsing:

  meta-updater/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_0.0.1.bb:do_install[depends], dependency ''][d.getVar('INITRAMFS_IMAGE') in 'virtual/kernel:do_deploy ${@['${INITRAMFS_IMAGE}:do_image_complete', ''][d.getVar('INITRAMFS_IMAGE') == '']} virtual/fakeroot-native:do_populate_sysroot' does not contain exactly one ':' character.
  Task 'depends' should be specified in the form 'packagename:task'

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>