### PR TITLE
ostree-kernel-initramfs: deploy dtbs from OSTREE_DEVICETREE

### DIFF
--- a/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_0.0.1.bb
+++ b/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_0.0.1.bb
@@ -41,7 +41,7 @@ do_install() {
 
         if [ ${@ oe.types.boolean('${OSTREE_DEPLOY_DEVICETREE}')} = True ] && [ -n "${OSTREE_DEVICETREE}" ]; then
             mkdir -p $kerneldir/dtb
-            for dts_file in ${KERNEL_DEVICETREE}; do
+            for dts_file in ${OSTREE_DEVICETREE}; do
                 dts_file_basename=$(basename $dts_file)
                 cp ${DEPLOY_DIR_IMAGE}/$dts_file_basename $kerneldir/dtb/$dts_file_basename
             done


### PR DESCRIPTION
Hi,

Following the discussion on https://github.com/advancedtelematic/meta-updater/pull/728, I was taking a look at whether my modification had been backported or not. Seeing that the kernel/ramfs/dtb deployment had changed quite a bit, I took some time to see what changed and noticed that the device tree shipment reverted back to KERNEL_DEVICETREE. This PR just fixes that, since it would be pain to miss the next round of backporting :smile:

-antznin 