### PR TITLE
ostree-kernel-initramfs: skip recipe when OSTREE_KERNEL is not defined

### DIFF
--- a/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_0.0.1.bb
+++ b/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_0.0.1.bb
@@ -51,3 +51,8 @@ do_install() {
 do_install[vardepsexclude] = "KERNEL_VERSION"
 INITRAMFS_IMAGE ?= ""
 do_install[depends] = "virtual/kernel:do_deploy ${@['${INITRAMFS_IMAGE}:do_image_complete', ''][d.getVar('INITRAMFS_IMAGE') == '']}"
+
+python() {
+    if not d.getVar('OSTREE_KERNEL'):
+        raise bb.parse.SkipRecipe('OSTREE_KERNEL is not defined, maybe your MACHINE config does not inherit sota.bbclass?')
+}


### PR DESCRIPTION
* otherwise it fails with useless error:
  ostree-kernel-initramfs/0.0.1-r0/temp/run.do_install.3011' failed with exit code 1:
  cp: -r not specified; omitting directory 'tmp-glibc/deploy/images/qemux86/'
  WARNING: exit code 1 from a shell command.

  because of
  cp ${DEPLOY_DIR_IMAGE}/${OSTREE_KERNEL} $kerneldir/vmlinuz
  in do_install will try to copy whole ${DEPLOY_DIR_IMAGE}/ when
  ${OSTREE_KERNEL} is empty

  as reported in:
  https://github.com/advancedtelematic/meta-updater/pull/740#issuecomment-651952735

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>