### PR TITLE
ostree-kernel-initramfs: fix devicetree deployment

### DIFF
--- a/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_0.0.1.bb
+++ b/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_0.0.1.bb
@@ -14,7 +14,9 @@ ALLOW_EMPTY_ostree-devicetrees = "1"
 
 FILES_ostree-kernel = "${nonarch_base_libdir}/modules/*/vmlinuz"
 FILES_ostree-initramfs = "${nonarch_base_libdir}/modules/*/initramfs.img"
-FILES_ostree-devicetrees = "${nonarch_base_libdir}/modules/*/dtb/*"
+FILES_ostree-devicetrees = "${nonarch_base_libdir}/modules/*/dtb/* \
+    ${nonarch_base_libdir}/modules/*/devicetree \
+"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
@@ -45,6 +47,7 @@ do_install() {
                 dts_file_basename=$(basename $dts_file)
                 cp ${DEPLOY_DIR_IMAGE}/$dts_file_basename $kerneldir/dtb/$dts_file_basename
             done
+            cp $kerneldir/dtb/$(basename $(echo ${OSTREE_DEVICETREE} | awk '{print $1}')) $kerneldir/devicetree
         fi
     fi
 }


### PR DESCRIPTION
Following the changes in ostree's deployment of the kernel, initramfs
and devicetree in /lib/modules/$kver, the deployment method of the
device tree also changed. Instead of picking the first device tree it
finds at a given location, ostree looks at a file named devicetree, next
to kernel and initramfs in /lib/modules/$kver.

This commit modifies ostree-kernel-initramfs to deploy the devicetree
from the sota-defined variable OSTREE_DEVICETREE. It will pick the
first one from the list of device trees that OSTREE_DEVICETREE defines,
and copy it to /lib/modules/$kver. Note that since OSTREE_DEVICETREE
equals to KERNEL_DEVICETREE when it isn't explicitly defined, it could
indeed be a list of device trees.

This defines the way ostree picks the devicetree https://github.com/ostreedev/ostree/blob/6ed48234ba579ff73eb128af237212b0a00f2057/src/libostree/ostree-sysroot-deploy.c#L1068 if I'm not mistaken.

Also, we could probably get rid of the `dtb` directory and pick the device tree from DEPLOY_DIR_IMAGE directly, since it isn't looked by ostree? Requesting comments from @patrickvacek and @liuming50 if you don't mind.