### PR TITLE
image_types_ota.bbclass: change IMAGE_BASENAME to PN

### DIFF
--- a/classes/image_types_ota.bbclass
+++ b/classes/image_types_ota.bbclass
@@ -128,4 +128,4 @@ IMAGE_CMD_ota-ext4 () {
 	mkfs.ext4 -O ^64bit ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.ota-ext4 -L otaroot -d ${OTA_SYSROOT}
 }
 
-do_image_wic[depends] += "${@bb.utils.contains('DISTRO_FEATURES', 'sota', '%s:do_image_ota_ext4' % d.getVar('IMAGE_BASENAME'), '', d)}"
+do_image_wic[depends] += "${@bb.utils.contains('DISTRO_FEATURES', 'sota', '%s:do_image_ota_ext4' % d.getVar('PN'), '', d)}"


### PR DESCRIPTION
When setting intertask dependencies, we should use PN instead of
IMAGE_BASENAME to refer to a image recipe, since PN is generated from
recipe file name, while IMAGE_BASENAME is a variable that could be
changed, it's not guaranteed to always equal to PN.

Signed-off-by: Ming Liu <ming.liu@toradex.com>