### PR TITLE
nfs-utils: fix nfs systemd daemons runtime issues

### DIFF
--- a/recipes-connectivity/nfs-utils/nfs-utils/nfs-home-mount.service
+++ b/recipes-connectivity/nfs-utils/nfs-utils/nfs-home-mount.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=NFS home mount @LOCALSTATEDIR@/local/lib/nfs -> @LOCALSTATEDIR@/lib/nfs.
+DefaultDependencies=no
+Conflicts=umount.target
+After=local-fs.target
+
+[Service]
+ExecStartPre=@BASE_BINDIR@/mkdir -p @LOCALSTATEDIR@/lib/nfs
+ExecStart=@BASE_BINDIR@/mount -o bind @LOCALSTATEDIR@/local/lib/nfs @LOCALSTATEDIR@/lib/nfs
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-connectivity/nfs-utils/nfs-utils_%.bbappend
+++ b/recipes-connectivity/nfs-utils/nfs-utils_%.bbappend
@@ -1,0 +1,25 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI += "file://nfs-home-mount.service"
+
+SYSTEMD_SERVICE_${PN} += "nfs-home-mount.service"
+
+CONFFILES_${PN}-client += "${localstatedir}/local/lib"
+
+do_install_append_sota () {
+    install -d ${D}${localstatedir}/local
+    cp -aPR ${D}${localstatedir}/lib ${D}${localstatedir}/local
+
+    install -m 0644 ${WORKDIR}/nfs-home-mount.service ${D}${systemd_unitdir}/system/
+    sed -i -e 's,@BASE_BINDIR@,${base_bindir},g' \
+           -e 's,@LOCALSTATEDIR@,${localstatedir},g' \
+           ${D}${systemd_unitdir}/system/nfs-home-mount.service
+
+    sed -i -e '0,/Requires=/{s,Requires=\(.*\),Requires=\1 nfs-home-mount.service,}' \
+           -e '0,/After=/{s,After=\(.*\),After=\1 nfs-home-mount.service,}' \
+           ${D}${systemd_unitdir}/system/nfs-statd.service
+
+    sed -i -e '0,/Requires=/{s,Requires=\(.*\),Requires=\1 nfs-home-mount.service,}' \
+           -e '0,/After=/{s,After=\(.*\),After=\1 nfs-home-mount.service,}' \
+           ${D}${systemd_unitdir}/system/nfs-mountd.service
+}


### PR DESCRIPTION
nfs-mountd.service and nfs-statd.service rely on /var/lib/nfs to be
present in rootfs, or else they would run into problems for some files
missing in it.

But a ostree/ota rootfs does not have that directory (removed during
do_image), to fix that, we now copy them to /var/local/lib/nfs and
mount it to /var/lib/nfs at runtime, which is done in
nfs-home-mount.service.

nfs-mountd.service and nfs-statd.service need run after
nfs-home-mount.service.

Signed-off-by: Ming Liu <ming.liu@toradex.com>