### PR TITLE
nfs-utils: don't add nfs-home-mount.service without sota enabled

### DIFF
--- a/recipes-connectivity/nfs-utils/nfs-utils_%.bbappend
+++ b/recipes-connectivity/nfs-utils/nfs-utils_%.bbappend
@@ -1,10 +1,10 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+FILESEXTRAPATHS_prepend_sota := "${THISDIR}/${BPN}:"
 
-SRC_URI += "file://nfs-home-mount.service"
+SRC_URI_append_sota = " file://nfs-home-mount.service"
 
-SYSTEMD_SERVICE_${PN} += "nfs-home-mount.service"
+SYSTEMD_SERVICE_${PN}_append_sota = " nfs-home-mount.service"
 
-CONFFILES_${PN}-client += "${localstatedir}/local/lib"
+CONFFILES_${PN}-client_append_sota = " ${localstatedir}/local/lib"
 
 do_install_append_sota () {
     install -d ${D}${localstatedir}/local


### PR DESCRIPTION
* nfs-home-mount.service is installed by do_install_append_sota, so only when sota is enabled
  but it was always added to SYSTEMD_SERVICE_ even when sota wasn't enabled resulting in
  do_patch failure:
  nfs-utils-2.5.1-r0 do_package: SYSTEMD_SERVICE_nfs-utils value nfs-home-mount.service does not exist

* use sota override everywhere

* fix issues introduced in
  https://github.com/advancedtelematic/meta-updater/pull/753

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>