### PR TITLE
Inherit python3native instead of using HOSTTOOLS.

### DIFF
--- a/classes/image_repo_manifest.bbclass
+++ b/classes/image_repo_manifest.bbclass
@@ -9,6 +9,8 @@
 # For more information, see:
 # https://web.archive.org/web/20161224194009/https://wiki.cyanogenmod.org/w/Doc:_Using_manifests 
 
+inherit python3native
+
 # Write build information to target filesystem
 buildinfo_manifest () {
   if [ $(which repo) ]; then

--- a/conf/distro/sota.conf.inc
+++ b/conf/distro/sota.conf.inc
@@ -18,4 +18,4 @@ export SOURCE_DATE_EPOCH = "0"
 REPRODUCIBLE_TIMESTAMP_ROOTFS = "0"
 
 HOSTTOOLS += "git sync sha256sum"
-HOSTTOOLS_NONFATAL += "java repo python"
+HOSTTOOLS_NONFATAL += "java repo"

--- a/recipes-test/big-update/big-update_1.0.bb
+++ b/recipes-test/big-update/big-update_1.0.bb
@@ -7,6 +7,8 @@ FILES_${PN} = "/usr/lib/big-update"
 
 DEPENDS = "coreutils-native"
 
+inherit python3native
+
 do_install() {
    install -d ${D}/usr/lib/big-update
    python ${S}/../rand_file.py ${D}/usr/lib/big-update/a-big-file $(numfmt --from=iec 10M)

--- a/recipes-test/big-update/big-update_2.0.bb
+++ b/recipes-test/big-update/big-update_2.0.bb
@@ -7,6 +7,8 @@ FILES_${PN} = "/usr/lib/big-update"
 
 DEPENDS = "coreutils-native"
 
+inherit python3native
+
 do_install() {
    install -d ${D}/usr/lib/big-update
    python ${S}/../rand_file.py ${D}/usr/lib/big-update/a-big-file $(numfmt --from=iec 12M)


### PR DESCRIPTION
Fixes https://github.com/advancedtelematic/meta-updater/issues/684.

@shr-project Can you confirm that this addresses the python concern you've raised? Are there further changes we should make?