### PR TITLE
sota_raspberrypi: Use new variable for bootfiles path.

### DIFF
--- a/classes/sota_raspberrypi.bbclass
+++ b/classes/sota_raspberrypi.bbclass
@@ -39,11 +39,12 @@ def make_dtb_boot_files(d):
 
     return ' '.join([transform(dtb) for dtb in alldtbs.split(' ') if dtb])
 
-IMAGE_BOOT_FILES_sota = "bcm2835-bootfiles/* \
+IMAGE_BOOT_FILES_sota = "${BOOTFILES_DIR_NAME}/* \
                          u-boot.bin;${SDIMG_KERNELIMAGE} \
                          "
 
-# OSTree puts its own boot.scr to bcm2835-bootfiles
+# OSTree puts its own boot.scr in ${BOOTFILES_DIR_NAME} (historically
+# bcm2835-bootfiles, now just bootfiles).
 # rpi4 and recent rpi3 firmwares needs dtb in /boot partition
 # so that they can be read by the firmware
 IMAGE_BOOT_FILES_append_sota = "${@make_dtb_boot_files(d)}"


### PR DESCRIPTION
This was changed in a907c3261ef583f898803706cd596d372c6644cb of meta-raspberrypi. This also requires 0b5292d13692ba074dc85227233e3a819d944204 in meta-updater-raspberrypi (see https://github.com/advancedtelematic/meta-updater-raspberrypi/pull/87).