### PR TITLE
sota_raspberrypi: Use new variable for bootfiles path.

### DIFF
--- a/classes/sota_raspberrypi.bbclass
+++ b/classes/sota_raspberrypi.bbclass
@@ -39,11 +39,12 @@ def make_dtb_boot_files(d):
 
     return ' '.join([transform(dtb) for dtb in alldtbs.split(' ') if dtb])
 
-IMAGE_BOOT_FILES_sota = "bcm2835-bootfiles/* \
+IMAGE_BOOT_FILES_sota = "${BOOTFILES_DIR_NAME}/* \
                          u-boot.bin;${SDIMG_KERNELIMAGE} \
                          "
 
-# OSTree puts its own boot.scr to bcm2835-bootfiles
+# OSTree puts its own boot.scr in ${BOOTFILES_DIR_NAME} (historically
+# bcm2835-bootfiles, now just bootfiles).
 # rpi4 and recent rpi3 firmwares needs dtb in /boot partition
 # so that they can be read by the firmware
 IMAGE_BOOT_FILES_append_sota = "${@make_dtb_boot_files(d)}"


### PR DESCRIPTION
This was changed in f046b4128c9ca3420614887006101fa2b10fc6e7 of meta-raspberrypi. This also requires e947e8590f74477505c754d016d99fc71cadf4e1 (see https://github.com/advancedtelematic/meta-updater-raspberrypi/pull/89) in meta-updater-raspberrypi.

(Cherry-picked from dunfell.)