### PR TITLE
image_repo_manifest.bbclass: explicitly call python3

### DIFF
--- a/classes/image_repo_manifest.bbclass
+++ b/classes/image_repo_manifest.bbclass
@@ -13,8 +13,9 @@ inherit python3native
 
 # Write build information to target filesystem
 buildinfo_manifest () {
-  if [ $(which repo) ]; then
-    repo manifest --revision-as-HEAD -o ${IMAGE_ROOTFS}${sysconfdir}/manifest.xml || bbwarn "Android repo tool failed to run; manifest not copied"
+  repotool=$(which repo)
+  if [ -n "$repotool" ]; then
+    python3 $repotool manifest --revision-as-HEAD -o ${IMAGE_ROOTFS}${sysconfdir}/manifest.xml || bbwarn "Android repo tool failed to run; manifest not copied"
   else
     bbwarn "Android repo tool not found; manifest not copied."
   fi


### PR DESCRIPTION
Now we have changed to inherit python3native to provide python3 binary
for repo, then we need explicitly call python3 to execute repo, or else
it will firstly try to locate python which will fail if python is not
in HOSTTOOLS.

This fixes a following warning:
| Android repo tool failed to run; manifest not copied

Signed-off-by: Ming Liu <ming.liu@toradex.com>