### PR TITLE
image_repo_manifest.bbclass: fix build when there is no repo on host

### DIFF
--- a/classes/image_repo_manifest.bbclass
+++ b/classes/image_repo_manifest.bbclass
@@ -13,7 +13,7 @@ inherit python3native
 
 # Write build information to target filesystem
 buildinfo_manifest () {
-  repotool=$(which repo)
+  repotool=`which repo || true`
   if [ -n "$repotool" ]; then
     python3 $repotool manifest --revision-as-HEAD -o ${IMAGE_ROOTFS}${sysconfdir}/manifest.xml || bbwarn "Android repo tool failed to run; manifest not copied"
   else


### PR DESCRIPTION
* failing "which repo" causes the run.buildinfo_manifest task to fail
  before it even reaches the test for empty repotool variable:

  dash -x some-image/1.0-r2/temp/run.buildinfo_manifest.80233

  + export systemd_system_unitdir=/usr/lib/systemd/system
  + export systemd_unitdir=/usr/lib/systemd
  + export systemd_user_unitdir=/usr/lib/systemd/user
  + buildinfo_manifest
  + which repo
  + repotool=
  + bb_sh_exit_handler
  + ret=1
  + [ 1 != 0 ]
  + echo WARNING: exit code 1 from a shell command.
  WARNING: exit code 1 from a shell command.
  + exit 1

  causing nasty long python exception from do_image task

  with this fix, it just shows an warning again:

  dash -x some-image/1.0-r2/temp/run.buildinfo_manifest.80233

  + export systemd_user_unitdir=/usr/lib/systemd/user
  + buildinfo_manifest
  + which repo
  + true
  + repotool=
  + [ -n  ]
  + bbwarn Android repo tool not found; manifest not copied.
  + [ -p some-image/1.0-r2/temp/fifo.80233 ]
  + echo WARNING: Android repo tool not found; manifest not copied.
  WARNING: Android repo tool not found; manifest not copied.
  + ret=0
  + trap  0
  + exit 0

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>