### PR TITLE
networkd-dhcp-conf: fix REQUIRED_DISTRO_FEATURES

### DIFF
--- a/recipes-connectivity/networkd-dhcp-conf/networkd-dhcp-conf.bb
+++ b/recipes-connectivity/networkd-dhcp-conf/networkd-dhcp-conf.bb
@@ -4,7 +4,7 @@ interfaces through systemd-networkd"
 LICENSE = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
 
-inherit systemd
+inherit systemd features_check
 
 RPROVIDES_${PN} = "network-configuration"
 
@@ -15,7 +15,7 @@ SRC_URI = " \
   "
 PR = "r1"
 
-REQUIRED_DISTRO_FEATURES_${PN} = "systemd"
+REQUIRED_DISTRO_FEATURES = "systemd"
 RCONFLICTS_${PN} = "connman"
 
 S = "${WORKDIR}"


### PR DESCRIPTION
* it's REQUIRED_DISTRO_FEATURES not REQUIRED_DISTRO_FEATURES_
* inherit features_check to actually respect REQUIRED_DISTRO_FEATURES
  and fix:
  ERROR: networkd-dhcp-conf-1.0-r1 do_package_qa: QA Issue: networkd-dhcp-conf: recipe doesn't inherit features_check [unhandled-features-check]
* fix:
  commit 4ae9917bf2475c118e8015ec7a2ce10bd01a0124
  Author: Mykhaylo Sul <ext-mykhaylo.sul@here.com>
  Date:   Fri Nov 1 11:44:44 2019 +0100

    OTA-3988: Don't build the networkd-dhcp recipe if systemd is not included into the disto feature list

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>