### PR TITLE
ostree-kernel-initramfs: add back initramfs fit workaround

### DIFF
--- a/classes/sota.bbclass
+++ b/classes/sota.bbclass
@@ -6,8 +6,7 @@ SOTA_HARDWARE_ID ??= "${MACHINE}"
 
 IMAGE_CLASSES += " image_types_ostree image_types_ota image_repo_manifest"
 IMAGE_INSTALL_append_sota = " aktualizr aktualizr-info ${SOTA_CLIENT_PROV} \
-                              ostree os-release ostree-kernel \
-                              ${@'ostree-initramfs' if d.getVar('KERNEL_IMAGETYPE') != 'fitImage' else ''} \
+                              ostree os-release ostree-kernel ostree-initramfs \
                               ${@'ostree-devicetrees' if oe.types.boolean('${OSTREE_DEPLOY_DEVICETREE}') else ''}"
 
 IMAGE_FSTYPES += "${@bb.utils.contains('DISTRO_FEATURES', 'sota', 'ostreepush garagesign garagecheck ota-ext4 wic', ' ', d)}"

--- a/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_0.0.1.bb
+++ b/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_0.0.1.bb
@@ -36,7 +36,13 @@ do_install() {
 
     cp ${DEPLOY_DIR_IMAGE}/${OSTREE_KERNEL} $kerneldir/vmlinuz
 
-    if [ "${KERNEL_IMAGETYPE}" != "fitImage" ]; then
+    if [ "${KERNEL_IMAGETYPE}" = "fitImage" ]; then
+        if [ -n "${INITRAMFS_IMAGE}" ]; then
+            # this is a hack for ostree not to override init= in kernel cmdline -
+            # make it think that the initramfs is present (while it is in FIT image)
+            touch $kerneldir/initramfs.img
+        fi
+    else
         if [ -n "${INITRAMFS_IMAGE}" ]; then
             cp ${DEPLOY_DIR_IMAGE}/${INITRAMFS_IMAGE}-${MACHINE}.${INITRAMFS_FSTYPES} $kerneldir/initramfs.img
         fi


### PR DESCRIPTION
Previous initramfs fit specific workaround was removed as part of commit
6eecf1593d, causing ostree to provide an init argument as part of the
kernel command line arguments when it is not really needed.

Bring back the workaround by simply generating an empty file in case
kernel image type is fit and initramfs is also used by the target.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>