### PR TITLE
image_types_ota.bbclass: call oe_mkext234fs to make ota-ext4 image

### DIFF
--- a/classes/image_types_ota.bbclass
+++ b/classes/image_types_ota.bbclass
@@ -69,7 +69,7 @@ IMAGE_CMD_ota () {
 	echo "{\"${ostree_target_hash}\":\"${GARAGE_TARGET_NAME}-${target_version}\"}" > ${OTA_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/sota/import/installed_versions
 }
 
-EXTRA_IMAGECMD_ota-ext4 = "-O ^64bit -L otaroot -i 4096"
+EXTRA_IMAGECMD_ota-ext4 = "-O ^64bit,^metadata_csum -L otaroot -i 4096"
 IMAGE_TYPEDEP_ota-ext4 = "ota"
 IMAGE_ROOTFS_task-image-ota-ext4 = "${OTA_SYSROOT}"
 IMAGE_CMD_ota-ext4 () {


### PR DESCRIPTION
We dont have to maintain our own function calculate_size and use
dd/mkfs.ext4 to generate ota-ext4 image, they have been done in OE
by get_rootfs_size/oe_mkext234fs functions, we could just use them.

The major benefit could be we can sync the future fixes/changes in
these functions from OE, also avoid maintaining some duplicated code in
image_types_ota.bbclass.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>