### PR TITLE
Use python3 to get repo working again.

### DIFF
--- a/scripts/ci/Dockerfile.checkout
+++ b/scripts/ci/Dockerfile.checkout
@@ -5,8 +5,11 @@ RUN sed -i 's#deb http://deb.debian.org/debian stretch main#deb http://deb.debia
 RUN sed -i 's#deb http://deb.debian.org/debian stretch-updates main#deb http://deb.debian.org/debian stretch-updates main contrib#g' /etc/apt/sources.list
 RUN apt-get update -q && apt-get install -qy \
     git \
-    repo \
-    xmlstarlet
+    xmlstarlet \
+    python3 \
+    repo
+
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 2
 
 # checkout script
 RUN mkdir /scripts


### PR DESCRIPTION
The latest version of repo requires python3.6+, but the default Debian package is fine with the default python3 package (although it complains about experimental support).