### PR TITLE
image_types_ota.bbclass: pass -t ext4 to mke2fs

### DIFF
--- a/classes/image_types_ota.bbclass
+++ b/classes/image_types_ota.bbclass
@@ -69,7 +69,7 @@ IMAGE_CMD_ota () {
 	echo "{\"${ostree_target_hash}\":\"${GARAGE_TARGET_NAME}-${target_version}\"}" > ${OTA_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/sota/import/installed_versions
 }
 
-EXTRA_IMAGECMD_ota-ext4 = "-O ^64bit,^metadata_csum -L otaroot -i 4096"
+EXTRA_IMAGECMD_ota-ext4 = "-O ^64bit,^metadata_csum -L otaroot -i 4096 -t ext4"
 IMAGE_TYPEDEP_ota-ext4 = "ota"
 IMAGE_ROOTFS_task-image-ota-ext4 = "${OTA_SYSROOT}"
 IMAGE_CMD_ota-ext4 () {


### PR DESCRIPTION
* it doesn't automatically pass "-t ext4", because here we're calling
  mke2fs as mkfs.ota-ext4 instead of mkfs.ext4

  so the resulting was now ext2 instead of ext4
  $ file image-raspberrypi4.rootfs.ota-ext4
  image-raspberrypi4.rootfs.ota-ext4: Linux rev 1.0 ext2 filesystem data, UUID=15862fcd-6204-486b-a4c6-fdf7b1710797, volume name "otaroot" (large files)
  after this fix:
  $ file image-raspberrypi4.rootfs.ota-ext4
  image-raspberrypi4.rootfs.ota-ext4: Linux rev 1.0 ext4 filesystem data, UUID=3709e65c-1d2b-4280-85d1-638f5f9c3cc0, volume name "otaroot" (extents) (64bit) (large files) (huge files)

  that's why metadata_csum and other features enabled by default
  in ext4 were now missing after
  https://github.com/advancedtelematic/meta-updater/pull/787
  we can drop 64bit feature as well, it's also enabled in default
  recipe-sysroot-native/etc/mke2fs.conf
      [defaults]
            base_features = sparse_super,large_file,filetype,resize_inode,dir_index,ext_attr
            default_mntopts = acl,user_xattr
            enable_periodic_fsck = 0
            blocksize = 4096
            inode_size = 256
            inode_ratio = 16384

      [fs_types]
            ext3 = {
                    features = has_journal
            }
            ext4 = {
                    features = has_journal,extent,huge_file,flex_bg,metadata_csum,64bit,dir_nlink,extra_isize
                    inode_size = 256
            }
      ...

Signed-off-by: Martin Jansa <martin.jansa@lge.com>
Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>