### PR TITLE
image_types_ota.bbclass: use standard ext4 features

### DIFF
--- a/classes/image_types_ota.bbclass
+++ b/classes/image_types_ota.bbclass
@@ -69,7 +69,7 @@ IMAGE_CMD_ota () {
 	echo "{\"${ostree_target_hash}\":\"${GARAGE_TARGET_NAME}-${target_version}\"}" > ${OTA_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/sota/import/installed_versions
 }
 
-EXTRA_IMAGECMD_ota-ext4 = "-O ^64bit,^metadata_csum -L otaroot -i 4096 -t ext4"
+EXTRA_IMAGECMD_ota-ext4 = "-L otaroot -i 4096 -t ext4"
 IMAGE_TYPEDEP_ota-ext4 = "ota"
 IMAGE_ROOTFS_task-image-ota-ext4 = "${OTA_SYSROOT}"
 IMAGE_CMD_ota-ext4 () {


### PR DESCRIPTION
Avoid removing 64bit and metadata_csum by default and prefer the
standard ext4 features instead.

64bit enables the file system to be larger than 2^32 blocks and
metadata_csum enables metadata checksumming, both of which are
enabled by default on recent mke2fs releases.

It is unclear why 64bit was disabled by looking at the git history, but
my assumption would be that either kernel or userspace was old enough
for this feature to not be supported/available. Since this option is
currently used by most distros by default, it should now be safe to
enable it (requires kernel >= 2.6.28).

metadata_csum was disabled in 4d34fa53db to make the u-boot tooling work
with the ext4 file system (when saving environment), but the correct fix
should instead be a fix at the userspace tooling instead, since not
every target requires u-boot.

This is a follow up of https://github.com/advancedtelematic/meta-updater/pull/791.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>