### PR TITLE
image_types_ota.bbclass: get lock before accessing OSTREE_REPO

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -163,6 +163,7 @@ IMAGE_CMD_ostreecommit () {
 
 IMAGE_TYPEDEP_ostreepush = "ostreecommit"
 do_image_ostreepush[depends] += "aktualizr-native:do_populate_sysroot ca-certificates-native:do_populate_sysroot"
+do_image_ostreepush[lockfiles] += "${OSTREE_REPO}/ostree.lock"
 IMAGE_CMD_ostreepush () {
     # send a copy of the repo manifest to backend if available
     local SEND_MANIFEST=""


### PR DESCRIPTION
In commit d13ec585ae677affd88b9d92c6ea135cc249b2fa:
[ image_types_ostree: use OSTree repo location for lockfiles ]

A lockfile ${OSTREE_REPO}/ostree.lock was added to prevent concurrent
access to the repository by multiple bitbake instances, but it should
not only apply to ostreecommit task, but ota task also needs it.

This fixes a following race condition error:
| | ERROR: Execution of '.../temp/run.do_image_ostreecommit.34262' failed with exit code 1:
| error: Writing content object: Creating temp file: No such file or directory

Signed-off-by: Ming Liu <liu.ming50@gmail.com>