### PR TITLE
image_repo_manifest.bbclass: Improvement for builds outside the .repo…

### DIFF
--- a/classes/image_repo_manifest.bbclass
+++ b/classes/image_repo_manifest.bbclass
@@ -15,7 +15,7 @@ inherit python3native
 buildinfo_manifest () {
   repotool=`which repo || true`
   if [ -n "$repotool" ]; then
-    python3 $repotool manifest --revision-as-HEAD -o ${IMAGE_ROOTFS}${sysconfdir}/manifest.xml || bbwarn "Android repo tool failed to run; manifest not copied"
+    cd ${THISDIR} && python3 $repotool manifest --revision-as-HEAD -o ${IMAGE_ROOTFS}${sysconfdir}/manifest.xml || bbwarn "Android repo tool failed to run; manifest not copied"
   else
     bbwarn "Android repo tool not found; manifest not copied."
   fi


### PR DESCRIPTION
… directory

The repo tool searches up the directory tree to find the .repo directory,
which doesn't work in a separated build directory.