### PR TITLE
ostree-kernel-initramfs: update LIC_FILES_CHKSUM

### DIFF
--- a/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_0.0.1.bb
+++ b/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_0.0.1.bb
@@ -2,7 +2,7 @@ SUMMARY = "Ostree linux kernel, devicetrees and initramfs packager"
 DESCRIPTION = "Ostree linux kernel, devicetrees and initramfs packager"
 SECTION = "kernel"
 LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 
 # Whilst not a module, this ensures we don't get multilib extended (which would make no sense)
 inherit module-base kernel-artifact-names


### PR DESCRIPTION
* the license file was renamed in:
  https://git.openembedded.org/openembedded-core/commit/?id=5ecf139a31fa7bd813855f1235ea9f434fbcb2e0

  and the build with latest oe-core is now failing with:
  WARNING: Could not copy license file TOPDIR/oe-core/meta/files/common-licenses/GPL-2.0 to TOPDIR/BUILD/work/raspberrypi3-oe-linux-gnueabi/ostree-kernel-initramfs/0.0.1-r0/license-destdir/ostree-kernel-initramfs/GPL-2.0: [Errno 2] No such file or directory: 'TOPDIR/oe-core/meta/files/common-licenses/GPL-2.0'

  ERROR: QA Issue: ostree-kernel-initramfs: LIC_FILES_CHKSUM points to an invalid file: TOPDIR/oe-core/meta/files/common-licenses/GPL-2.0 [license-checksum]
  ERROR: Fatal QA errors found, failing task.

* unfortunately this would be first meta-updater commit which
  isn't backwards compatible with gatesgarth (for which there
  isn't separate branch). So either gatesgarth branch should
  be created before this or maybe we should discuss if this
  LICENSE value is actually correct (e.g. MIT license files
  weren't renamed) and this recipe doesn't have own source,
  the initramfs itself should be covered by the recipe which
  provides whatever is set in INITRAMFS_IMAGE and kernel from
  virtual/kernel, but ostree-kernel-initramfs recipe is only
  metadata, so it might make sense to use MIT (as COPYING.MIT
  in the root of the repo) or MPL-2 like other metadata-only
  recipes in this layer (is it intentionally MPL-2 instead of
  more common for metadata MIT?):

recipes-connectivity/networkd-dhcp-conf/networkd-dhcp-conf.bb:LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
recipes-sota/aktualizr/aktualizr-collectd.bb:LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
recipes-sota/aktualizr/aktualizr-device-prov-hsm.bb:LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
recipes-sota/aktualizr/aktualizr-device-prov.bb:LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
recipes-sota/aktualizr/aktualizr-hwid.bb:LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
recipes-sota/aktualizr/aktualizr-shared-prov-creds.bb:LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
recipes-sota/aktualizr/aktualizr-shared-prov.bb:LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
recipes-sota/aktualizr/aktualizr-uboot-env-rollback.bb:LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
recipes-sota/config/aktualizr-auto-reboot.bb:LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
recipes-sota/config/aktualizr-binary-pacman.bb:LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
recipes-sota/config/aktualizr-disable-send-ip.bb:LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
recipes-sota/config/aktualizr-log-debug.bb:LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
recipes-sota/config/aktualizr-polling-interval.bb:LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
recipes-sota/config/aktualizr-virtualsec.bb:LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
recipes-sota/ostree/ostree-booted_1.0.bb:LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
recipes-support/systemd-journald-persistent/systemd-journald-persistent.bb:LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
recipes-test/demo-config/primary-config.bb:LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
recipes-test/demo-config/secondary-config.bb:LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
recipes-test/demo-network-config/primary-network-config.bb:LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
recipes-test/demo-network-config/secondary-network-config.bb:LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>