### PR TITLE
ostree-kernel-initramfs: Use MIT license.

### DIFF
--- a/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_0.0.1.bb
+++ b/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_0.0.1.bb
@@ -1,8 +1,8 @@
 SUMMARY = "Ostree linux kernel, devicetrees and initramfs packager"
 DESCRIPTION = "Ostree linux kernel, devicetrees and initramfs packager"
 SECTION = "kernel"
-LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 # Whilst not a module, this ensures we don't get multilib extended (which would make no sense)
 inherit module-base kernel-artifact-names


### PR DESCRIPTION
It's a metadata-only recipe and all contributors have agreed that MIT would be preferable.

FYI @shr-project. This effectively replaces https://github.com/advancedtelematic/meta-updater/pull/801.