### PR TITLE
fit-conf, ostree-initrd, slcand-start: use COMMON_LICENSE_DIR instead…

### DIFF
--- a/recipes-sota/fit-conf/fit-conf.bb
+++ b/recipes-sota/fit-conf/fit-conf.bb
@@ -1,6 +1,6 @@
 SUMMARY = "FIT image configuration for u-boot to use"
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 

--- a/recipes-sota/ostree-initrd/ostree-initrd.bb
+++ b/recipes-sota/ostree-initrd/ostree-initrd.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Initramfs for booting into libostree managed system"
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 SRC_URI = "file://init.sh"
 

--- a/recipes-support/slcand-start/slcand-start.bb
+++ b/recipes-support/slcand-start/slcand-start.bb
@@ -1,8 +1,6 @@
 SUMMARY = "Mock smartcard for aktualizr"
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690 \
-                    file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
-
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 inherit systemd
 


### PR DESCRIPTION
… of COREBASE in LIC_FILES_CHKSUM

* fixes slcand-start which fails since LICENSE file was changed in 2019 with:
  https://git.openembedded.org/openembedded-core/commit/LICENSE?id=f8c9c511b5f1b7dbd45b77f345cb6c048ae6763e

  WARNING: slcand-start-1.0-r0 do_populate_lic: ${COREBASE}/LICENSE is not a valid license file, please use '${COMMON_LICENSE_DIR}/MIT' for a MIT License file in LIC_FILES_CHKSUM. This will become an error in the future
  ERROR: slcand-start-1.0-r0 do_populate_lic: QA Issue: slcand-start: The LIC_FILES_CHKSUM does not match for file://oe-core/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690
  slcand-start: The new md5 checksum is b97a012949927931feb7793eee5ed924

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>