### PR TITLE
image_types_ostree.bbclass: add fakeroot varflag to prepare_ostree_ro…

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -31,6 +31,7 @@ python prepare_ostree_rootfs() {
     image_rootfs = d.getVar("IMAGE_ROOTFS")
     oe.path.copyhardlinktree(image_rootfs, ostree_rootfs)
 }
+prepare_ostree_rootfs[fakeroot] = "1"
 
 do_image_ostree[dirs] = "${OSTREE_ROOTFS}"
 do_image_ostree[prefuncs] += "prepare_ostree_rootfs"


### PR DESCRIPTION
…otfs

Since the ostree rootfs is generated by fakeroot, we should make
prepare_ostree_rootfs run with fakeroot as well, or else we might run
into a pseudo abort issue when removing OSTREE_ROOTFS directory.

Reference:
https://wiki.yoctoproject.org/wiki/Pseudo_Abort

Signed-off-by: Ming Liu <liu.ming50@gmail.com>