### PR TITLE
aktualizr: drop unnecessary do_configure_prepend

### DIFF
--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -70,14 +70,6 @@ RESOURCE_CPU_WEIGHT = "100"
 RESOURCE_MEMORY_HIGH = "100M"
 RESOURCE_MEMORY_MAX = "80%"
 
-do_configure_prepend() {
-    # CMake has trouble finding yocto's git when cross-compiling, let's do this step manually
-    cd ${S}
-    if [ ! -f VERSION ]; then
-        ./scripts/get_version.sh > VERSION
-    fi
-}
-
 do_compile_ptest() {
     cmake_runcmake_build --target build_tests "${PARALLEL_MAKE}"
 }


### PR DESCRIPTION
* fails with latest oe-core/master with:
  https://git.openembedded.org/openembedded-core/commit/meta/classes/cmake.bbclass?id=0fb6280432a36985590d9a714a5f11164aaebb51

  because this prepend does "cd ${S}" and doesn't go back to ${B} and
  cmake_do_configure function doesn't cd to ${B} anymore, resulting in:

  | CMake Error at CMakeLists.txt:42 (message):
  |   Aktualizr does not support building in the source tree.  Please remove
  |   CMakeCache.txt and the CMakeFiles/ directory, then create a subdirectory to
  |   build in: mkdir build; cd build; cmake ..

* drop this whole do_configure_prepend as git-native works fine:

  aktualizr-native/1.0+gitAUTOINC+1255aa24fe-7/git$ grep Setting ../temp/log.do_configure
  -- Setting version to 2020.10-0-g1255aa24f

  aktualizr/1.0+gitAUTOINC+1255aa24fe-7/temp$ grep Setting ../temp/log.do_configure
  -- Setting version to 2020.10-0-g1255aa24f

  aktualizr/1.0+gitAUTOINC+1255aa24fe-7/build$ which git
  /OE/build/oe-core/tmp-musl/hosttools/git

  aktualizr/1.0+gitAUTOINC+1255aa24fe-7/build$ grep GIT CMakeCache.txt
  GITCOMMAND:FILEPATH=/OE/build/oe-core/tmp-musl/hosttools/git
  GIT_EXECUTABLE:FILEPATH=/OE/build/oe-core/tmp-musl/hosttools/git
  //ADVANCED property for variable: GITCOMMAND
  GITCOMMAND-ADVANCED:INTERNAL=1
  //ADVANCED property for variable: GIT_EXECUTABLE
  GIT_EXECUTABLE-ADVANCED:INTERNAL=1

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>