### PR TITLE
image_types_ostree.bbclass: drop prepare_ostree_rootfs prefunc

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -19,24 +19,13 @@ CONVERSIONTYPES_append = " tar"
 
 TAR_IMAGE_ROOTFS_task-image-ostree = "${OSTREE_ROOTFS}"
 
-python prepare_ostree_rootfs() {
-    import oe.path
-    import shutil
-
-    ostree_rootfs = d.getVar("OSTREE_ROOTFS")
-    if os.path.lexists(ostree_rootfs):
-        bb.utils.remove(ostree_rootfs, True)
-
-    # Copy required as we change permissions on some files.
-    image_rootfs = d.getVar("IMAGE_ROOTFS")
-    oe.path.copyhardlinktree(image_rootfs, ostree_rootfs)
-}
-prepare_ostree_rootfs[fakeroot] = "1"
-
 do_image_ostree[dirs] = "${OSTREE_ROOTFS}"
-do_image_ostree[prefuncs] += "prepare_ostree_rootfs"
+do_image_ostree[cleandirs] = "${OSTREE_ROOTFS}"
 do_image_ostree[depends] = "coreutils-native:do_populate_sysroot virtual/kernel:do_deploy ${INITRAMFS_IMAGE}:do_image_complete"
 IMAGE_CMD_ostree () {
+    # Copy required as we change permissions on some files.
+    tar --xattrs --xattrs-include='*' -cf - -S -C ${IMAGE_ROOTFS} -p . | tar --xattrs --xattrs-include='*' -xf - -C ${OSTREE_ROOTFS}
+
     for d in var/*; do
       if [ "${d}" != "var/local" ]; then
         rm -rf ${d}


### PR DESCRIPTION
The purpose of prepare_ostree_rootfs prefunc is to ensure
do_image_rootfs runs from a clean ${OSTREE_ROOTFS} and call
oe.path.copyhardlinktree from ${IMAGE_ROOTFS} to ${OSTREE_ROOTFS}.

We dont have to maintain a prefunc to achieve that, it could be easily
done in do_image_ostree itself.

But the major reason for this change is to avoid hard links from
${IMAGE_ROOTFS} to ${OSTREE_ROOTFS}, which might lead to a Pseudo
abortion in some cases, which was observed when IMA/EVM is enabled
in rootfs.

There was a commit aiming to fix the Pseudo abortion, commit db099053:
[ image_types_ostree.bbclass: add fakeroot varflag to prepare_ostree_rootfs ]

but it's incomplete per later tests, there is still the case some old
inodes being used in ${IMAGE_ROOTFS} when do_rootfs runs, which causes
'rm -rf ${IMAGE_ROOTFS}' fail on a Pseudo abortion error.

This fixes the Pseudo abortion completely.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>