### PR TITLE
image_types_ota.bbclass: add support for syslinux as OSTREE_BOOTLOADER

### DIFF
--- a/classes/image_types_ota.bbclass
+++ b/classes/image_types_ota.bbclass
@@ -21,6 +21,10 @@ IMAGE_CMD_ota () {
 		ln -s ../loader/grub.cfg ${OTA_SYSROOT}/boot/grub2/grub.cfg
 	elif [ "${OSTREE_BOOTLOADER}" = "u-boot" ]; then
 		touch ${OTA_SYSROOT}/boot/loader/uEnv.txt
+	elif [ "${OSTREE_BOOTLOADER}" = "syslinux" ]; then
+		mkdir -p ${OTA_SYSROOT}/boot/syslinux
+		touch ${OTA_SYSROOT}/boot/loader/syslinux.cfg
+		ln -s ../loader/syslinux.cfg ${OTA_SYSROOT}/boot/syslinux/syslinux.cfg
 	else
 		bbfatal "Invalid bootloader: ${OSTREE_BOOTLOADER}"
 	fi


### PR DESCRIPTION
Add support for ostree to automatically identify and use syslinux as the
preferred bootloader scheme when set via OSTREE_BOOTLOADER.

Not forcing a build-time dependency at do_image_ota as multiple
bootloaders are able to identify the syslinux format.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>