### PR TITLE
Return python2 to Docker image

### DIFF
--- a/scripts/ci/Dockerfile.bitbake
+++ b/scripts/ci/Dockerfile.bitbake
@@ -17,6 +17,7 @@ RUN apt-get update -q && apt-get install --no-install-suggests --no-install-reco
      git-core \
      iputils-ping \
      iproute2 \
+     libpython-dev \
      libpython3-dev \
      libsdl1.2-dev \
      libvirt-clients \
@@ -25,6 +26,7 @@ RUN apt-get update -q && apt-get install --no-install-suggests --no-install-reco
      ovmf \
      openssh-client \
      procps \
+     python \
      python3 \
      python3-pexpect \
      qemu-kvm \


### PR DESCRIPTION
Our pipelines for older releases of Yocto ( warrior, thud, zeus ) started failing a long time ago. Looks like this version also needs python2. At least it is the fastest way to fix pipelines.