### PR TITLE
Compatibility with kirkstone

### DIFF
--- a/conf/distro/sota.conf.inc
+++ b/conf/distro/sota.conf.inc
@@ -7,13 +7,9 @@
 DISTRO_FEATURES:append = " sota usrmerge"
 DISTRO_FEATURES_NATIVE:append = " sota"
 INHERIT += " sota"
-# Prelinking increases the size of downloads and causes build errors
-USER_CLASSES:remove = "image-prelink"
 
-# Enable reproducible builds. Use 0 as mtime, the same as OSTree is using.
-INHERIT:remove = "reproducible_build"
-INHERIT += "reproducible_build_simple"
-
+# Reproducible builds are enabled by default since kirkstone
+# Use 0 as mtime, the same as OSTree is using.
 export SOURCE_DATE_EPOCH = "0"
 REPRODUCIBLE_TIMESTAMP_ROOTFS = "0"
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,7 +12,7 @@ BBFILE_PRIORITY_sota = "7"
 LAYERDEPENDS_sota = "openembedded-layer"
 LAYERDEPENDS_sota += "meta-python"
 LAYERDEPENDS_sota += "filesystems-layer"
-LAYERSERIES_COMPAT_sota = "dunfell gatesgarth hardknott honister"
+LAYERSERIES_COMPAT_sota = "kirkstone"
 
 SIGGEN_EXCLUDE_SAFE_RECIPE_DEPS += " \
   aktualizr-device-prov->aktualizr \

--- a/conf/local.conf.base.append
+++ b/conf/local.conf.base.append
@@ -15,4 +15,4 @@ DISTRO = "##DISTRO##"
 
 # Uncomment this line to set the log level of aktualizr to 'debug' (from 'info'
 # by default)
-#IMAGE_INSTALL_append += " aktualizr-log-debug"
+#IMAGE_INSTALL:append += " aktualizr-log-debug"

--- a/conf/local.conf.systemd.append
+++ b/conf/local.conf.systemd.append
@@ -9,7 +9,7 @@ IMAGE_INSTALL:append += " systemd-journald-persistent"
 #
 # Uncomment these lines to change the default parameters.
 #
-#RESOURCE_CPU_WEIGHT_pn-aktualizr = "100"
-#RESOURCE_MEMORY_HIGH_pn-aktualizr = "100M"
-#RESOURCE_MEMORY_MAX_pn-aktualizr = "80%"
+#RESOURCE_CPU_WEIGHT:pn-aktualizr = "100"
+#RESOURCE_MEMORY_HIGH:pn-aktualizr = "100M"
+#RESOURCE_MEMORY_MAX:pn-aktualizr = "80%"
 IMAGE_INSTALL:append += " aktualizr-resource-control"

--- a/recipes-sota/aktualizr/aktualizr_git.bb
+++ b/recipes-sota/aktualizr/aktualizr_git.bb
@@ -19,7 +19,7 @@ PR = "7"
 GARAGE_SIGN_PV = "0.7.2-9-g80ae114"
 
 SRC_URI = " \
-  gitsm://github.com/advancedtelematic/aktualizr;branch=${BRANCH};name=aktualizr \
+  gitsm://github.com/advancedtelematic/aktualizr;branch=${BRANCH};name=aktualizr;protocol=https \
   file://run-ptest \
   file://aktualizr.service \
   file://aktualizr-secondary.service \


### PR DESCRIPTION
Hi,

We updated meta-updater internally to be compatible with kirkstone. Maybe you can reuse what we did.

Unfortunately I think that with the removal of the reproducible_build_simple the layer is not compatible anymore with previous versions, although I don't really understand why you used the "simple" variant of reproducible build.