### PR TITLE
ostree-initrd: move /run mount point to sysroot/run

### DIFF
--- a/recipes-sota/ostree-initrd/files/init.sh
+++ b/recipes-sota/ostree-initrd/files/init.sh
@@ -65,6 +65,10 @@ mount "$ostree_sysroot" /sysroot || {
 
 ostree-prepare-root /sysroot
 
+mkdir -p /sysroot/run
+#Move /run(initramfs) to /sysroot/run(real-rootfs) 
+mount --move /run /sysroot/run
+
 log_info "Switching to rootfs"
 exec switch_root /sysroot /sbin/init
 


### PR DESCRIPTION
This change relocates the /run mount point from initramfs (/run) to the real root filesystem (sysroot/run). This ensures that systemd does not remount it during switchroot if it detects an existing mount point. Consequently, all contents of /run will be transferred to the real root filesystem.
This adjustment resolves the issue of mounting sysroot as  read-only. During the execution of ostree-remount.service, the system checks /run/ostree-booted to determine if sysroot should be mounted as read-only.